### PR TITLE
feat: 서비스 실패 테스트 추가 작성 & 테스트 가독성 향상(#97)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.0.3'
 	id 'io.spring.dependency-management' version '1.1.0'
+	id 'jacoco'
 }
 
 group = 'io.wisoft'
@@ -42,10 +43,12 @@ dependencies {
 	implementation 'org.json:json:20230227'
 	implementation 'com.github.iamport:iamport-rest-client-java:0.2.22'
 	testImplementation 'junit:junit:4.13.1'
+	testImplementation 'io.github.autoparams:autoparams:1.1.1'
     compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
+	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/io/wisoft/capstonedesign/domain/donate/web/dto/CreateDonateRequest.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/donate/web/dto/CreateDonateRequest.java
@@ -1,6 +1,8 @@
 package io.wisoft.capstonedesign.domain.donate.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record CreateDonateRequest(@NotBlank String title, String image, @NotBlank String text, String tag, Long userId) {
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/donate/web/dto/UpdateDonateRequest.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/donate/web/dto/UpdateDonateRequest.java
@@ -1,6 +1,8 @@
 package io.wisoft.capstonedesign.domain.donate.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record UpdateDonateRequest(@NotBlank String title, String image, @NotBlank String text, String tag, Long donateId) {
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/donateorder/web/dto/CreateOrderRequest.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/donateorder/web/dto/CreateOrderRequest.java
@@ -1,6 +1,8 @@
 package io.wisoft.capstonedesign.domain.donateorder.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record CreateOrderRequest(@NotBlank String text, Long infoId, Long donateId, Long userId) {
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/donateorder/web/dto/UpdateOrderRequest.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/donateorder/web/dto/UpdateOrderRequest.java
@@ -1,6 +1,8 @@
 package io.wisoft.capstonedesign.domain.donateorder.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record UpdateOrderRequest(@NotBlank String text, Long orderId) {
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/find/web/dto/CreateFindRequest.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/find/web/dto/CreateFindRequest.java
@@ -1,6 +1,8 @@
 package io.wisoft.capstonedesign.domain.find.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record CreateFindRequest(@NotBlank String title, String image, @NotBlank String text, String tag, Long userId) {
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/find/web/dto/UpdateFindRequest.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/find/web/dto/UpdateFindRequest.java
@@ -1,6 +1,8 @@
 package io.wisoft.capstonedesign.domain.find.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record UpdateFindRequest(@NotBlank String title, String image, @NotBlank String text, String tag, Long findId) {
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/findorder/web/dto/CreateOrderRequest.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/findorder/web/dto/CreateOrderRequest.java
@@ -1,6 +1,8 @@
 package io.wisoft.capstonedesign.domain.findorder.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record CreateOrderRequest(@NotBlank String text, Long infoId, Long findId, Long userId) {
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/findorder/web/dto/UpdateOrderRequest.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/findorder/web/dto/UpdateOrderRequest.java
@@ -1,6 +1,8 @@
 package io.wisoft.capstonedesign.domain.findorder.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record UpdateOrderRequest(@NotBlank String text, Long orderId) {
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/information/web/dto/CreateInformationRequest.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/information/web/dto/CreateInformationRequest.java
@@ -1,6 +1,8 @@
 package io.wisoft.capstonedesign.domain.information.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record CreateInformationRequest(@NotBlank String username, @NotBlank String address, @NotBlank String phoneNumber, Long userId) {
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/information/web/dto/UpdateInformationRequest.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/information/web/dto/UpdateInformationRequest.java
@@ -1,6 +1,8 @@
 package io.wisoft.capstonedesign.domain.information.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record UpdateInformationRequest(@NotBlank String username, @NotBlank String address, @NotBlank String phoneNumber, Long infoId) {
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/shop/application/ShopService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/shop/application/ShopService.java
@@ -4,7 +4,10 @@ import io.wisoft.capstonedesign.domain.shop.persistence.Shop;
 import io.wisoft.capstonedesign.domain.shop.persistence.ShopRepository;
 import io.wisoft.capstonedesign.domain.shop.web.dto.CreateShopRequest;
 import io.wisoft.capstonedesign.domain.shop.web.dto.UpdateShopRequest;
+import io.wisoft.capstonedesign.domain.user.persistence.User;
+import io.wisoft.capstonedesign.domain.user.persistence.UserRepository;
 import io.wisoft.capstonedesign.global.exception.service.PostNotFoundException;
+import io.wisoft.capstonedesign.global.exception.service.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,20 +16,22 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static io.wisoft.capstonedesign.global.exception.ErrorCode.*;
-
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ShopService {
 
     private final ShopRepository shopRepository;
+    private final UserRepository userRepository;
 
     /**
      * 산타샵 물품 저장
      */
     @Transactional
     public Long save(final CreateShopRequest request) {
+
+        User user = userRepository.findById(request.userId())
+                .orElseThrow(UserNotFoundException::new);
 
         Shop shop = Shop.builder()
                 .title(request.title())

--- a/src/main/java/io/wisoft/capstonedesign/domain/shop/web/dto/CreateShopRequest.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/shop/web/dto/CreateShopRequest.java
@@ -2,6 +2,8 @@ package io.wisoft.capstonedesign.domain.shop.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 
+@Builder
 public record CreateShopRequest(@NotBlank String title, @NotNull int price, @NotBlank String image, String body, Long userId) {
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/shop/web/dto/UpdateShopRequest.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/shop/web/dto/UpdateShopRequest.java
@@ -2,6 +2,8 @@ package io.wisoft.capstonedesign.domain.shop.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 
+@Builder
 public record UpdateShopRequest(@NotBlank String title, @NotNull int price, @NotBlank String image, @NotBlank String body, Long shopId) {
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/user/web/dto/CreateUserRequest.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/user/web/dto/CreateUserRequest.java
@@ -3,10 +3,12 @@ package io.wisoft.capstonedesign.domain.user.web.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 
+@Builder
 public record CreateUserRequest(
         @NotBlank String oauthId,
-        @Email String email,
+        @Email @NotBlank String email,
         @NotBlank String profileImage,
         @NotNull int point,
         @NotBlank String nickname,

--- a/src/main/java/io/wisoft/capstonedesign/domain/user/web/dto/UpdateUserRequest.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/user/web/dto/UpdateUserRequest.java
@@ -2,5 +2,5 @@ package io.wisoft.capstonedesign.domain.user.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record UpdateUserRequest(@NotBlank String nickname) {
+public record UpdateUserRequest(@NotBlank(message = "닉네임을 입력해주세요.") String nickname) {
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/usershop/application/UserShopService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/usershop/application/UserShopService.java
@@ -4,13 +4,16 @@ import io.wisoft.capstonedesign.domain.information.persistence.Information;
 import io.wisoft.capstonedesign.domain.information.persistence.InformationRepository;
 import io.wisoft.capstonedesign.domain.shop.persistence.Shop;
 import io.wisoft.capstonedesign.domain.shop.persistence.ShopRepository;
-import io.wisoft.capstonedesign.domain.user.persistence.UserRepository;
-import io.wisoft.capstonedesign.domain.usershop.persistence.UserShopRepository;
 import io.wisoft.capstonedesign.domain.user.persistence.User;
+import io.wisoft.capstonedesign.domain.user.persistence.UserRepository;
 import io.wisoft.capstonedesign.domain.usershop.persistence.UserShop;
+import io.wisoft.capstonedesign.domain.usershop.persistence.UserShopRepository;
 import io.wisoft.capstonedesign.domain.usershop.web.dto.CreateOrderRequest;
 import io.wisoft.capstonedesign.domain.usershop.web.dto.UpdateOrderRequest;
-import io.wisoft.capstonedesign.global.exception.service.*;
+import io.wisoft.capstonedesign.global.exception.service.InfoNotFoundException;
+import io.wisoft.capstonedesign.global.exception.service.OrderNotFoundException;
+import io.wisoft.capstonedesign.global.exception.service.PostNotFoundException;
+import io.wisoft.capstonedesign.global.exception.service.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,8 +21,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-
-import static io.wisoft.capstonedesign.global.exception.ErrorCode.*;
 
 @Service
 @Transactional(readOnly = true)
@@ -89,7 +90,7 @@ public class UserShopService {
      */
     @Transactional
     public void updateBody(final Long id, final UpdateOrderRequest request) {
-        UserShop userShop = userShopRepository.findById(request.orderId())
+        UserShop userShop = userShopRepository.findById(id)
                 .orElseThrow(OrderNotFoundException::new);
         userShop.update(request.text());
     }

--- a/src/main/java/io/wisoft/capstonedesign/domain/usershop/web/dto/CreateOrderRequest.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/usershop/web/dto/CreateOrderRequest.java
@@ -1,6 +1,8 @@
 package io.wisoft.capstonedesign.domain.usershop.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record CreateOrderRequest(@NotBlank String text, Long infoId, Long shopId, Long userId) {
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/usershop/web/dto/UpdateOrderRequest.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/usershop/web/dto/UpdateOrderRequest.java
@@ -1,6 +1,8 @@
 package io.wisoft.capstonedesign.domain.usershop.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record UpdateOrderRequest(@NotBlank String text, Long orderId) {
 }

--- a/src/test/java/io/wisoft/capstonedesign/service/DonateServiceTest.java
+++ b/src/test/java/io/wisoft/capstonedesign/service/DonateServiceTest.java
@@ -4,11 +4,13 @@ import io.wisoft.capstonedesign.domain.donate.application.DonateService;
 import io.wisoft.capstonedesign.domain.donate.persistence.Donate;
 import io.wisoft.capstonedesign.domain.donate.web.dto.CreateDonateRequest;
 import io.wisoft.capstonedesign.domain.donate.web.dto.UpdateDonateRequest;
-import io.wisoft.capstonedesign.domain.user.web.dto.CreateUserRequest;
-import io.wisoft.capstonedesign.global.enumerated.Role;
-import io.wisoft.capstonedesign.global.enumerated.Tag;
 import io.wisoft.capstonedesign.domain.user.application.UserService;
+import io.wisoft.capstonedesign.domain.user.web.dto.CreateUserRequest;
+import io.wisoft.capstonedesign.global.enumerated.Tag;
 import io.wisoft.capstonedesign.global.exception.service.PostNotFoundException;
+import io.wisoft.capstonedesign.global.exception.service.UserNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,7 +20,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static io.wisoft.capstonedesign.setting.data.DefaultDonateData.createDefaultDonate;
+import static io.wisoft.capstonedesign.setting.data.DefaultUserData.createDefaultUser;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Transactional
@@ -27,130 +32,281 @@ public class DonateServiceTest {
     @Autowired DonateService donateService;
     @Autowired UserService userService;
 
-    @Test
-    public void 게시글_작성() throws Exception {
+    @Nested
+    @DisplayName("게시글 작성 테스트")
+    class WritePost {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateDonateRequest request2 = new CreateDonateRequest("패딩 나눔합니다", "image.png", "안 입는 패딩 기부해요", String.valueOf(Tag.TOP), 1L);
+        @Test
+        @DisplayName("게시글 작성시 정상적으로 저장되어야 한다.")
+        void write_post() {
 
-        // when
-        userService.join(request1);
-        Long savedId = donateService.join(request2);
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(request2.title(), donateService.findById(savedId).getTitle());
+            CreateDonateRequest donateRequest = createDefaultDonate(userId);
+
+            // when
+            Long savedId = donateService.join(donateRequest);
+
+            // then
+            Donate donate = donateService.findById(savedId);
+            assertEquals("패딩 나눔합니다.", donate.getTitle());
+        }
+
+        @Test
+        @DisplayName("회원이 아닌 사용자가 게시글 작성시 예외가 발생해야 한다.")
+        void write_post_fail() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            userService.join(userRequest);
+
+            CreateDonateRequest donateRequest = createDefaultDonate(100L);
+
+            // when
+
+            // then
+            assertThrows(UserNotFoundException.class, () -> donateService.join(donateRequest));
+        }
     }
 
-    @Test
-    public void 게시글_조회() throws Exception {
+    @Nested
+    @DisplayName("게시글 조회 테스트")
+    class FindPost {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateDonateRequest request2 = new CreateDonateRequest("패딩 나눔합니다", "image.png", "안 입는 패딩 기부해요", String.valueOf(Tag.TOP), 1L);
+        @Test
+        @DisplayName("게시글 단건 조회 요청시 한 게시글이 조회되어야 한다.")
+        void find_single_post() {
 
-        // when
-        userService.join(request1);
-        Long savedId = donateService.join(request2);
-        Donate savedDonate = donateService.findById(savedId);
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(request2.title(), savedDonate.getTitle());
+            CreateDonateRequest donateRequest = createDefaultDonate(userId);
+            Long savedId = donateService.join(donateRequest);
+
+            // when
+            Donate savedDonate = donateService.findById(savedId);
+
+            // then
+            assertEquals("패딩 나눔합니다.", savedDonate.getTitle());
+            assertEquals("안 입는 패딩 기부해요", savedDonate.getText());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 게시글을 조회시 예외가 발생해야 한다.")
+        void find_single_post_fail() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateDonateRequest donateRequest = createDefaultDonate(userId);
+            donateService.join(donateRequest);
+
+            // when
+
+            // then
+            assertThrows(PostNotFoundException.class, () -> donateService.findById(100L));
+        }
+
+        @Test
+        @DisplayName("전체 게시글 조회시 전체 게시글 목록을 반환해야 한다.")
+        void find_donate_posts() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateDonateRequest donateRequest1 = createDefaultDonate(userId);
+            donateService.join(donateRequest1);
+
+            CreateDonateRequest donateRequest2 = CreateDonateRequest.builder()
+                    .title("바지 나눔합니다.")
+                    .image("image.png")
+                    .text("안 입는 바지 기부해요")
+                    .tag(String.valueOf(Tag.PANTS))
+                    .userId(userId)
+                    .build();
+            donateService.join(donateRequest2);
+
+            // when
+            List<Donate> donates = donateService.findDonates();
+
+            // then
+            assertEquals(2, donates.size());
+            assertEquals("패딩 나눔합니다.", donates.get(0).getTitle());
+        }
+
+        @Test
+        @DisplayName("전체 게시글을 페이징을 사용하여 조회시 페이지 번호와 내림차순으로 정렬된 페이지가 반환되어야 한다.")
+        void find_posts_using_paging() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateDonateRequest donateRequest1 = createDefaultDonate(userId);
+            donateService.join(donateRequest1);
+
+            CreateDonateRequest donateRequest2 = CreateDonateRequest.builder()
+                    .title("바지 나눔합니다.")
+                    .image("image.png")
+                    .text("안 입는 바지 기부해요")
+                    .tag(String.valueOf(Tag.PANTS))
+                    .userId(userId)
+                    .build();
+            donateService.join(donateRequest2);
+
+            CreateDonateRequest donateRequest3 = CreateDonateRequest.builder()
+                    .title("후드티 나눔합니다.")
+                    .image("image.png")
+                    .text("안 입는 후드티 기부해요")
+                    .tag(String.valueOf(Tag.TOP))
+                    .userId(userId)
+                    .build();
+            donateService.join(donateRequest3);
+            PageRequest request = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+
+            // when
+            List<Donate> donates = donateService.findByCreatedDateDescUsingPaging(request).getContent();
+
+            // then
+            assertEquals("후드티 나눔합니다.", donates.get(0).getTitle());
+        }
+
+        @Test
+        @DisplayName("전체 게시글을 태그별로 조회시 태그에 맞는 게시글만 반환되어야 한다.")
+        void find_posts_by_tag() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateDonateRequest donateRequest = createDefaultDonate(userId);
+            donateService.join(donateRequest);
+
+            CreateDonateRequest donateRequest2 = CreateDonateRequest.builder()
+                    .title("바지 나눔합니다.")
+                    .image("image.png")
+                    .text("안 입는 바지 기부해요")
+                    .tag(String.valueOf(Tag.PANTS))
+                    .userId(userId)
+                    .build();
+            donateService.join(donateRequest2);
+
+            CreateDonateRequest donateRequest3 = CreateDonateRequest.builder()
+                    .title("후드티 나눔합니다.")
+                    .image("image.png")
+                    .text("안 입는 후드티 기부해요")
+                    .tag(String.valueOf(Tag.TOP))
+                    .userId(userId)
+                    .build();
+            donateService.join(donateRequest3);
+
+            // when
+            List<Donate> byTag = donateService.findByTag(Tag.TOP);
+
+            // then
+            assertEquals(2, byTag.size());
+        }
     }
 
-    @Test
-    public void 전체_게시글_조회() throws Exception {
+    @Nested
+    @DisplayName("게시글 수정 테스트")
+    class UpdatePost {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateDonateRequest request2 = new CreateDonateRequest("패딩 나눔합니다", "image.png", "안 입는 패딩 기부해요", String.valueOf(Tag.TOP), 1L);
-        CreateDonateRequest request3 = new CreateDonateRequest("바지 나눔합니다", "image.png", "안 입는 바지 기부해요", String.valueOf(Tag.PANTS), 1L);
+        @Test
+        @DisplayName("게시글 수정시 게시글이 수정되어야 한다.")
+        void update_post() {
 
-        // when
-        userService.join(request1);
-        donateService.join(request2);
-        donateService.join(request3);
-        List<Donate> donates = donateService.findDonates();
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(2, donates.size());
+            CreateDonateRequest donateRequest = createDefaultDonate(userId);
+            Long savedId = donateService.join(donateRequest);
+
+            UpdateDonateRequest updateRequest = UpdateDonateRequest.builder()
+                    .title("바지 나눔합니다")
+                    .image("image.png")
+                    .text("안 입는 바지 기부해요")
+                    .tag(String.valueOf(Tag.PANTS))
+                    .donateId(userId)
+                    .build();
+
+            // when
+            donateService.updateAll(savedId, updateRequest);
+            Donate updateDonate = donateService.findById(savedId);
+
+            // then
+            assertEquals("바지 나눔합니다", updateDonate.getTitle());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 게시글을 수정시 예외가 발생해야 한다.")
+        void update_post_fail() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateDonateRequest donateRequest = createDefaultDonate(userId);
+            donateService.join(donateRequest);
+
+            UpdateDonateRequest updateRequest = UpdateDonateRequest.builder()
+                    .title("바지 나눔합니다")
+                    .image("image.png")
+                    .text("안 입는 바지 기부해요")
+                    .tag(String.valueOf(Tag.PANTS))
+                    .donateId(userId)
+                    .build();
+
+            // when
+
+            // then
+            assertThrows(PostNotFoundException.class, () -> donateService.updateAll(100L, updateRequest));
+        }
     }
 
-    @Test
-    public void 전체_게시글_최근순_조회_페이징() throws Exception {
+    @Nested
+    @DisplayName("게시글 삭제 테스트")
+    class DeletePost {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateUserRequest request2 = new CreateUserRequest("2", "donggwon@gmail.com", "profile.png", 2000, "donggwon", String.valueOf(Role.GENERAL));
-        CreateDonateRequest request3 = new CreateDonateRequest("패딩 나눔합니다", "image.png", "안 입는 패딩 기부해요", String.valueOf(Tag.TOP), 1L);
-        CreateDonateRequest request4 = new CreateDonateRequest("바지 나눔합니다", "image.png", "안 입는 바지 기부해요", String.valueOf(Tag.PANTS), 2L);
-        PageRequest request = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+        @Test
+        @DisplayName("게시글 삭제시 게시글이 삭제되어야 한다.")
+        void delete_post() {
 
-        // when
-        userService.join(request1);
-        userService.join(request2);
-        donateService.join(request3);
-        donateService.join(request4);
-        List<Donate> donates = donateService.findByCreatedDateDescUsingPaging(request).getContent();
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(request4.title(), donates.get(0).getTitle());
-    }
+            CreateDonateRequest donateRequest = createDefaultDonate(userId);
+            Long savedId = donateService.join(donateRequest);
 
-    @Test
-    public void 전체_게시글_태그별_조회() throws Exception {
+            // when
+            donateService.deleteDonate(savedId);
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateDonateRequest request2 = new CreateDonateRequest("패딩 나눔합니다", "image.png", "안 입는 패딩 기부해요", String.valueOf(Tag.TOP), 1L);
-        CreateDonateRequest request3 = new CreateDonateRequest("바지 나눔합니다", "image.png", "안 입는 바지 기부해요", String.valueOf(Tag.PANTS), 1L);
-        CreateDonateRequest request4 = new CreateDonateRequest("후드티 나눔합니다", "image.png", "안 입는 후드티 기부해요", String.valueOf(Tag.TOP), 1L);
+            // then
+            assertThrows(PostNotFoundException.class, () -> donateService.findById(savedId));
+        }
 
-        // when
-        userService.join(request1);
-        donateService.join(request2);
-        donateService.join(request3);
-        donateService.join(request4);
-        List<Donate> byTag = donateService.findByTag(Tag.TOP);
+        @Test
+        @DisplayName("존재하지 않는 게시글을 삭제시 예외가 발생해야 한다.")
+        void delete_post_fail() {
 
-        // then
-        assertEquals(2, byTag.size());
-    }
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-    @Test
-    public void 게시글_전체_수정() throws Exception {
+            CreateDonateRequest donateRequest = createDefaultDonate(userId);
+            donateService.join(donateRequest);
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateDonateRequest request2 = new CreateDonateRequest("패딩 나눔합니다", "image.png", "안 입는 패딩 기부해요", String.valueOf(Tag.TOP), 1L);
+            // when
 
-        // when
-        userService.join(request1);
-        Long donateId = donateService.join(request2);
-
-        UpdateDonateRequest updateRequest = new UpdateDonateRequest("바지 나눔합니다", "image.png", "안 입는 바지 기부해요", String.valueOf(Tag.PANTS), 1L);
-        donateService.updateAll(donateId, updateRequest);
-        Donate updateDonate = donateService.findById(donateId);
-
-        // then
-        assertEquals("바지 나눔합니다", updateDonate.getTitle());
-        System.out.println(updateDonate.getView()); // 조회수 확인
-    }
-
-    @Test
-    public void 게시글_삭제() throws Exception {
-
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateDonateRequest request2 = new CreateDonateRequest("패딩 나눔합니다", "image.png", "안 입는 패딩 기부해요", String.valueOf(Tag.TOP), 1L);
-
-        // when
-        userService.join(request1);
-        Long donateId = donateService.join(request2);
-
-        donateService.deleteDonate(donateId);
-
-        // then
-        assertThrows(PostNotFoundException.class, () -> donateService.findById(donateId));
+            // then
+            assertThrows(PostNotFoundException.class, () -> donateService.deleteDonate(100L));
+        }
     }
 }

--- a/src/test/java/io/wisoft/capstonedesign/service/FindOrderServiceTest.java
+++ b/src/test/java/io/wisoft/capstonedesign/service/FindOrderServiceTest.java
@@ -6,23 +6,30 @@ import io.wisoft.capstonedesign.domain.findorder.application.FindOrderService;
 import io.wisoft.capstonedesign.domain.findorder.persistence.FindOrder;
 import io.wisoft.capstonedesign.domain.findorder.web.dto.CreateOrderRequest;
 import io.wisoft.capstonedesign.domain.findorder.web.dto.UpdateOrderRequest;
-import io.wisoft.capstonedesign.domain.information.web.dto.CreateInformationRequest;
-import io.wisoft.capstonedesign.domain.user.web.dto.CreateUserRequest;
-import io.wisoft.capstonedesign.global.enumerated.Role;
-import io.wisoft.capstonedesign.global.enumerated.Tag;
 import io.wisoft.capstonedesign.domain.information.application.InformationService;
+import io.wisoft.capstonedesign.domain.information.web.dto.CreateInformationRequest;
 import io.wisoft.capstonedesign.domain.user.application.UserService;
+import io.wisoft.capstonedesign.domain.user.web.dto.CreateUserRequest;
 import io.wisoft.capstonedesign.global.exception.service.OrderNotFoundException;
+import io.wisoft.capstonedesign.global.exception.service.UserNotFoundException;
+import io.wisoft.capstonedesign.setting.data.DefaultFindOrderData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static io.wisoft.capstonedesign.setting.data.DefaultFindData.createDefaultFind;
+import static io.wisoft.capstonedesign.setting.data.DefaultInfoData.createDefaultInfo;
+import static io.wisoft.capstonedesign.setting.data.DefaultUserData.createDefaultUser;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Transactional
@@ -33,153 +40,310 @@ public class FindOrderServiceTest {
     @Autowired FindService findService;
     @Autowired InformationService informationService;
 
-    @Test
-    public void 주문내역_생성() throws Exception {
+    @Nested
+    @DisplayName("주문내역 생성 테스트")
+    class CreateOrder {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateFindRequest request2 = new CreateFindRequest("패딩 찾아봅니다", "image.png", "안 입는 패딩 기부받아요", String.valueOf(Tag.TOP), 1L);
-        CreateInformationRequest request3 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateOrderRequest request4 = new CreateOrderRequest("배송전 문자주세요", 1L, 1L, 1L);
+        @Test
+        @DisplayName("주문내역 생성시 정상적으로 주문이 되어야 한다.")
+        void create_order() {
 
-        // when
-        userService.join(request1);
-        findService.join(request2);
-        informationService.save(request3);
-        Long savedId = findOrderService.save(request4);
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(request4.text(), findOrderService.findById(savedId).getText());
+            CreateFindRequest findRequest = createDefaultFind(userId);
+            Long findId = findService.join(findRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest);
+
+            CreateOrderRequest orderRequest = DefaultFindOrderData.createDefaultOrder(infoId, findId, userId);
+
+            // when
+            Long savedId = findOrderService.save(orderRequest);
+
+            // then
+            FindOrder order = findOrderService.findById(savedId);
+            assertEquals("배송전 문자주세요", order.getText());
+        }
+
+        @Test
+        @DisplayName("회원이 아닌 사용자가 주문할시 예외가 발생해야 한다.")
+        void create_order_fail() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateFindRequest findRequest = createDefaultFind(userId);
+            Long findId = findService.join(findRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest);
+
+            CreateOrderRequest orderRequest = DefaultFindOrderData.createDefaultOrder(infoId, findId, 100L);
+
+            // when
+
+            // then
+            assertThrows(UserNotFoundException.class, () -> findOrderService.save(orderRequest));
+        }
+
+        @Test
+        @DisplayName("배송정보 없이 주문할시 예외가 발생해야 한다.")
+        void create_order_fail2() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateFindRequest findRequest = createDefaultFind(userId);
+            Long findId = findService.join(findRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            informationService.save(infoRequest);
+
+            CreateOrderRequest orderRequest = DefaultFindOrderData.createDefaultOrder(null, findId, userId);
+
+            // when
+
+            // then
+            assertThrows(InvalidDataAccessApiUsageException.class, () -> findOrderService.save(orderRequest));
+        }
     }
 
-    @Test
-    public void 주문내역_조회() throws Exception {
+    @Nested
+    @DisplayName("주문내역 조회 테스트")
+    class FindOrders {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateFindRequest request2 = new CreateFindRequest("패딩 찾아봅니다", "image.png", "안 입는 패딩 기부받아요", String.valueOf(Tag.TOP), 1L);
-        CreateInformationRequest request3 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateOrderRequest request4 = new CreateOrderRequest("배송전 문자주세요", 1L, 1L, 1L);
+        @Test
+        @DisplayName("주문내역 단건 조회 요청시 한 주문내역이 조회되어야 한다.")
+        void find_single_order() {
 
-        // when
-        userService.join(request1);
-        findService.join(request2);
-        informationService.save(request3);
-        Long savedId = findOrderService.save(request4);
-        FindOrder savedOrder = findOrderService.findById(savedId);
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(request4.text(), savedOrder.getText());
+            CreateFindRequest findRequest = createDefaultFind(userId);
+            Long findId = findService.join(findRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest);
+
+            CreateOrderRequest orderRequest = DefaultFindOrderData.createDefaultOrder(infoId, findId, userId);
+            Long savedId = findOrderService.save(orderRequest);
+
+            // when
+            FindOrder savedOrder = findOrderService.findById(savedId);
+
+            // then
+            assertEquals("배송전 문자주세요", savedOrder.getText());
+            assertEquals(infoId, savedOrder.getInformation().getId());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 주문내역을 조회시 예외가 발생해야 한다.")
+        void find_single_order_fail() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateFindRequest findRequest = createDefaultFind(userId);
+            Long findId = findService.join(findRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest);
+
+            CreateOrderRequest orderRequest = DefaultFindOrderData.createDefaultOrder(infoId, findId, userId);
+            findOrderService.save(orderRequest);
+
+            // when
+
+            // then
+            assertThrows(OrderNotFoundException.class, () -> findOrderService.findById(100L));
+        }
+
+        @Test
+        @DisplayName("전체 주문내역 조회시 전체 주문내역 목록을 반환해야 한다.")
+        void find_orders() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateFindRequest findRequest = createDefaultFind(userId);
+            Long findId = findService.join(findRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest);
+
+            CreateOrderRequest orderRequest1 = DefaultFindOrderData.createDefaultOrder(infoId, findId, userId);
+            findOrderService.save(orderRequest1);
+
+            CreateOrderRequest orderRequest2 = CreateOrderRequest.builder()
+                    .text("경비실에 맡겨주세요")
+                    .infoId(infoId)
+                    .findId(findId)
+                    .userId(userId)
+                    .build();
+            findOrderService.save(orderRequest2);
+
+            // when
+            List<FindOrder> orders = findOrderService.findFindOrders();
+
+            // then
+            assertEquals(2, orders.size());
+            assertEquals("경비실에 맡겨주세요", orders.get(1).getText());
+        }
+
+        @Test
+        @DisplayName("전체 주문내역을 페이징을 사용하여 조회시 페이지 번호와 내림차순으로 정렬된 페이지가 반환되어야 한다.")
+        void find_orders_using_paging() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateFindRequest findRequest = createDefaultFind(userId);
+            Long findId = findService.join(findRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest);
+
+            CreateOrderRequest orderRequest1 = DefaultFindOrderData.createDefaultOrder(infoId, findId, userId);
+            findOrderService.save(orderRequest1);
+
+            CreateOrderRequest orderRequest2 = CreateOrderRequest.builder()
+                    .text("경비실에 맡겨주세요")
+                    .infoId(infoId)
+                    .findId(findId)
+                    .userId(userId)
+                    .build();
+            findOrderService.save(orderRequest2);
+            PageRequest request = PageRequest.of(0, 5, Sort.by("sendDate").descending());
+
+            // when
+            List<FindOrder> donateOrders = findOrderService.findByCreatedDateDescUsingPaging(request).getContent();
+
+            // then
+            assertEquals("경비실에 맡겨주세요", donateOrders.get(0).getText());
+        }
     }
 
-    @Test
-    public void 전체_주문내역_조회() throws Exception {
+    @Nested
+    @DisplayName("주문내역 수정 테스트")
+    class UpdateOrder {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateFindRequest request2 = new CreateFindRequest("패딩 찾아봅니다", "image.png", "안 입는 패딩 기부받아요", String.valueOf(Tag.TOP), 1L);
-        CreateInformationRequest request3 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateOrderRequest request4 = new CreateOrderRequest("배송전 문자주세요", 1L, 1L, 1L);
-        CreateOrderRequest request5 = new CreateOrderRequest("경비실에 맡겨주세요", 1L, 1L, 1L);
+        @Test
+        @DisplayName("주문내역 수정시 주문내역 기타사항이 수정되어야 한다.")
+        void update_order() {
 
-        // when
-        userService.join(request1);
-        findService.join(request2);
-        informationService.save(request3);
-        findOrderService.save(request4);
-        findOrderService.save(request5);
-        List<FindOrder> findOrders = findOrderService.findFindOrders();
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(2, findOrders.size());
+            CreateFindRequest findRequest = createDefaultFind(userId);
+            Long findId = findService.join(findRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest);
+
+            CreateOrderRequest orderRequest = DefaultFindOrderData.createDefaultOrder(infoId, findId, userId);
+            Long orderId = findOrderService.save(orderRequest);
+
+            UpdateOrderRequest updateRequest = UpdateOrderRequest.builder()
+                    .text("경비실에 맡겨주세요")
+                    .orderId(orderId)
+                    .build();
+
+            // when
+            findOrderService.updateBody(orderId, updateRequest);
+            FindOrder updateOrder = findOrderService.findById(orderId);
+
+            // then
+            assertEquals("경비실에 맡겨주세요", updateOrder.getText());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 주문내역을 수정시 예외가 발생해야 한다.")
+        void update_order_fail() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateFindRequest findRequest = createDefaultFind(userId);
+            Long findId = findService.join(findRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest);
+
+            CreateOrderRequest orderRequest = DefaultFindOrderData.createDefaultOrder(infoId, findId, userId);
+            Long orderId = findOrderService.save(orderRequest);
+
+            UpdateOrderRequest updateRequest = UpdateOrderRequest.builder()
+                    .text("경비실에 맡겨주세요")
+                    .orderId(orderId)
+                    .build();
+
+            // when
+
+            // then
+            assertThrows(OrderNotFoundException.class, () -> findOrderService.updateBody(100L, updateRequest));
+        }
     }
 
-    @Test
-    public void 전체_주문내역_조회_페이() throws Exception {
+    @Nested
+    @DisplayName("주문내역 삭제 테스트")
+    class DeleteOrder {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateFindRequest request2 = new CreateFindRequest("패딩 찾아봅니다", "image.png", "안 입는 패딩 기부받아요", String.valueOf(Tag.TOP), 1L);
-        CreateInformationRequest request3 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateOrderRequest request4 = new CreateOrderRequest("배송전 문자주세요", 1L, 1L, 1L);
-        CreateOrderRequest request5 = new CreateOrderRequest("경비실에 맡겨주세요", 1L, 1L, 1L);
-        PageRequest request = PageRequest.of(0, 5, Sort.by("sendDate").descending());
+        @Test
+        @DisplayName("주문내역 삭제시 주문내역이 삭제되어야 한다.")
+        void delete_order() {
 
-        // when
-        userService.join(request1);
-        findService.join(request2);
-        informationService.save(request3);
-        findOrderService.save(request4);
-        findOrderService.save(request5);
-        List<FindOrder> findOrders = findOrderService.findByCreatedDateDescUsingPaging(request).getContent();
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(request5.text(), findOrders.get(0).getText());
-    }
+            CreateFindRequest findRequest = createDefaultFind(userId);
+            Long findId = findService.join(findRequest);
 
-    @Test
-    public void 개별_주문내역_최근순_조회() throws Exception {
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest);
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateFindRequest request2 = new CreateFindRequest("패딩 찾아봅니다", "image.png", "안 입는 패딩 기부받아요", String.valueOf(Tag.TOP), 1L);
-        CreateInformationRequest request3 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateOrderRequest request4 = new CreateOrderRequest("배송전 문자주세요", 1L, 1L, 1L);
-        CreateOrderRequest request5 = new CreateOrderRequest("경비실에 맡겨주세요", 1L, 1L, 1L);
+            CreateOrderRequest orderRequest = DefaultFindOrderData.createDefaultOrder(infoId, findId, userId);
+            Long orderId = findOrderService.save(orderRequest);
 
-        // when
-        Long userId = userService.join(request1);
-        findService.join(request2);
-        informationService.save(request3);
-        findOrderService.save(request4);
-        findOrderService.save(request5);
-        List<FindOrder> orderDESC = findOrderService.findByUser(userId);
+            // when
+            findOrderService.deleteOrder(orderId);
 
-        // then
-        assertEquals(request5.text(), orderDESC.get(0).getText());
-    }
+            // then
+            assertThrows(OrderNotFoundException.class, () -> findOrderService.findById(orderId));
+        }
 
-    @Test
-    public void 주문내역_기타사항_수정() throws Exception {
+        @Test
+        @DisplayName("존재하지 않는 주문내역을 삭제시 예외가 발생해야 한다.")
+        void delete_order_fail() {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateFindRequest request2 = new CreateFindRequest("패딩 찾아봅니다", "image.png", "안 입는 패딩 기부받아요", String.valueOf(Tag.TOP), 1L);
-        CreateInformationRequest request3 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateOrderRequest request4 = new CreateOrderRequest("배송전 문자주세요", 1L, 1L, 1L);
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // when
-        userService.join(request1);
-        findService.join(request2);
-        informationService.save(request3);
-        Long savedId = findOrderService.save(request4);
+            CreateFindRequest findRequest = createDefaultFind(userId);
+            Long findId = findService.join(findRequest);
 
-        UpdateOrderRequest updateRequest = new UpdateOrderRequest("경비실에 맡겨주세요", 1L);
-        findOrderService.updateBody(savedId, updateRequest);
-        FindOrder updateOrder = findOrderService.findById(savedId);
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest);
 
-        // then
-        assertEquals("경비실에 맡겨주세요", updateOrder.getText());
-    }
+            CreateOrderRequest orderRequest = DefaultFindOrderData.createDefaultOrder(infoId, findId, userId);
+            Long orderId = findOrderService.save(orderRequest);
 
-    @Test
-    public void 주문내역_삭제() throws Exception {
+            // when
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateFindRequest request2 = new CreateFindRequest("패딩 찾아봅니다", "image.png", "안 입는 패딩 기부받아요", String.valueOf(Tag.TOP), 1L);
-        CreateInformationRequest request3 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateOrderRequest request4 = new CreateOrderRequest("배송전 문자주세요", 1L, 1L, 1L);
-
-        // when
-        userService.join(request1);
-        findService.join(request2);
-        informationService.save(request3);
-        Long savedId = findOrderService.save(request4);
-
-        findOrderService.deleteOrder(savedId);
-
-        // then
-        assertThrows(OrderNotFoundException.class, () -> findOrderService.findById(savedId));
+            // then
+            assertThrows(OrderNotFoundException.class, () -> findOrderService.deleteOrder(100L));
+        }
     }
 }

--- a/src/test/java/io/wisoft/capstonedesign/service/FindServiceTest.java
+++ b/src/test/java/io/wisoft/capstonedesign/service/FindServiceTest.java
@@ -4,11 +4,13 @@ import io.wisoft.capstonedesign.domain.find.application.FindService;
 import io.wisoft.capstonedesign.domain.find.persistence.Find;
 import io.wisoft.capstonedesign.domain.find.web.dto.CreateFindRequest;
 import io.wisoft.capstonedesign.domain.find.web.dto.UpdateFindRequest;
-import io.wisoft.capstonedesign.domain.user.web.dto.CreateUserRequest;
-import io.wisoft.capstonedesign.global.enumerated.Role;
-import io.wisoft.capstonedesign.global.enumerated.Tag;
 import io.wisoft.capstonedesign.domain.user.application.UserService;
+import io.wisoft.capstonedesign.domain.user.web.dto.CreateUserRequest;
+import io.wisoft.capstonedesign.global.enumerated.Tag;
 import io.wisoft.capstonedesign.global.exception.service.PostNotFoundException;
+import io.wisoft.capstonedesign.global.exception.service.UserNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,139 +20,295 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static io.wisoft.capstonedesign.setting.data.DefaultFindData.createDefaultFind;
+import static io.wisoft.capstonedesign.setting.data.DefaultUserData.createDefaultUser;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Transactional
 public class FindServiceTest {
 
-    @Autowired FindService findService;
-    @Autowired UserService userService;
+    @Autowired
+    FindService findService;
+    @Autowired
+    UserService userService;
 
-    @Test
-    public void 게시글_작성() throws Exception {
+    @Nested
+    @DisplayName("게시글 작성 테스트")
+    class WritePost {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateFindRequest request2 = new CreateFindRequest("패딩 찾아봅니다", "image.png", "안 입는 패딩 기부받아요", String.valueOf(Tag.TOP), 1L);
+        @Test
+        @DisplayName("게시글 작성시 정상적으로 저장되어야 한다.")
+        void write_post() {
 
-        // when
-        userService.join(request1);
-        Long savedId = findService.join(request2);
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(request2.title(), findService.findById(savedId).getTitle());
+            CreateFindRequest findRequest = createDefaultFind(userId);
+
+            // when
+            Long savedId = findService.join(findRequest);
+
+            // then
+            Find find = findService.findById(savedId);
+            assertEquals("패딩 찾아봅니다", find.getTitle());
+        }
+
+        @Test
+        @DisplayName("회원이 아닌 사용자가 게시글 작성시 예외가 발생해야 한다.")
+        void write_post_fail() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            userService.join(userRequest);
+
+            CreateFindRequest findRequest = createDefaultFind(100L);
+
+            // when
+
+            // then
+            assertThrows(UserNotFoundException.class, () -> findService.join(findRequest));
+        }
     }
 
-    @Test
-    public void 게시글_조회() throws Exception {
+    @Nested
+    @DisplayName("게시글 조회 테스트")
+    class FindPost {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateFindRequest request2 = new CreateFindRequest("패딩 찾아봅니다", "image.png", "안 입는 패딩 기부받아요", String.valueOf(Tag.TOP), 1L);
+        @Test
+        @DisplayName("게시글 단건 조회 요청시 한 게시글이 조회되어야 한다.")
+        void find_single_post() {
 
-        // when
-        userService.join(request1);
-        Long savedId = findService.join(request2);
-        Find savedFind = findService.findById(savedId);
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(request2.title(), savedFind.getTitle());
+            CreateFindRequest findRequest = createDefaultFind(userId);
+            Long savedId = findService.join(findRequest);
+
+            // when
+            Find savedFind = findService.findById(savedId);
+
+            // then
+            assertEquals("패딩 찾아봅니다", savedFind.getTitle());
+            assertEquals("안 입는 패딩 기부받아요", savedFind.getText());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 게시글을 조회시 예외가 발생해야 한다.")
+        void find_single_post_fail() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateFindRequest findRequest = createDefaultFind(userId);
+            Long savedId = findService.join(findRequest);
+
+            // when
+
+            // then
+            assertThrows(PostNotFoundException.class, () -> findService.findById(100L));
+        }
+
+        @Test
+        @DisplayName("전체 게시글 조회시 전체 게시글 목록을 반환해야 한다.")
+        void find_find_posts() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateFindRequest findRequest1 = createDefaultFind(userId);
+            findService.join(findRequest1);
+
+            CreateFindRequest findRequest2 = CreateFindRequest.builder()
+                    .title("바지 찾아봅니다")
+                    .image("image.png")
+                    .text("안 입는 바지 기부받아요")
+                    .tag(String.valueOf(Tag.PANTS))
+                    .userId(userId)
+                    .build();
+            findService.join(findRequest2);
+
+            // when
+            List<Find> finds = findService.findFinds();
+
+            // then
+            assertEquals(2, finds.size());
+            assertEquals("패딩 찾아봅니다", finds.get(0).getTitle());
+        }
+
+        @Test
+        @DisplayName("전체 게시글을 페이징을 사용하여 조회시 페이지 번호와 내림차순으로 정렬된 페이지가 반환되어야 한다.")
+        void find_posts_using_paging() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateFindRequest findRequest1 = createDefaultFind(userId);
+            findService.join(findRequest1);
+
+            CreateFindRequest findRequest2 = CreateFindRequest.builder()
+                    .title("바지 찾아봅니다")
+                    .image("image.png")
+                    .text("안 입는 바지 기부받아요")
+                    .tag(String.valueOf(Tag.PANTS))
+                    .userId(userId)
+                    .build();
+            findService.join(findRequest2);
+
+            CreateFindRequest findRequest3 = CreateFindRequest.builder()
+                    .title("후드티 찾아봅니다")
+                    .image("image.png")
+                    .text("안 입는 후드티 기부받아요")
+                    .tag(String.valueOf(Tag.TOP))
+                    .userId(userId)
+                    .build();
+            findService.join(findRequest3);
+            PageRequest request = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+
+            // when
+            List<Find> finds = findService.findByCreatedDateDescUsingPaging(request).getContent();
+
+            // then
+            assertEquals("후드티 찾아봅니다", finds.get(0).getTitle());
+        }
+
+        @Test
+        @DisplayName("전체 게시글을 태그별로 조회시 태그에 맞는 게시글만 반환되어야 한다.")
+        void find_posts_by_tag() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateFindRequest findRequest1 = createDefaultFind(userId);
+            findService.join(findRequest1);
+
+            CreateFindRequest findRequest2 = CreateFindRequest.builder()
+                    .title("바지 찾아봅니다")
+                    .image("image.png")
+                    .text("안 입는 바지 기부받아요")
+                    .tag(String.valueOf(Tag.PANTS))
+                    .userId(userId)
+                    .build();
+            findService.join(findRequest2);
+
+            CreateFindRequest findRequest3 = CreateFindRequest.builder()
+                    .title("후드티 찾아봅니다")
+                    .image("image.png")
+                    .text("안 입는 후드티 기부받아요")
+                    .tag(String.valueOf(Tag.TOP))
+                    .userId(userId)
+                    .build();
+            findService.join(findRequest3);
+
+            // when
+            List<Find> byTag = findService.findByTag(Tag.TOP);
+
+            // then
+            assertEquals(2, byTag.size());
+        }
     }
 
-    @Test
-    public void 전체_게시글_조회() throws Exception {
+    @Nested
+    @DisplayName("게시글 수정 테스트")
+    class UpdatePost {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateFindRequest request2 = new CreateFindRequest("패딩 찾아봅니다", "image.png", "안 입는 패딩 기부받아요", String.valueOf(Tag.TOP), 1L);
-        CreateFindRequest request3 = new CreateFindRequest("바지 찾아봅니다", "image.png", "안 입는 바지 기부받아요", String.valueOf(Tag.PANTS), 1L);
+        @Test
+        @DisplayName("게시글 수정시 게시글이 수정되어야 한다.")
+        void update_post() {
 
-        // when
-        userService.join(request1);
-        findService.join(request2);
-        findService.join(request3);
-        List<Find> finds = findService.findFinds();
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(2, finds.size());
+            CreateFindRequest findRequest = createDefaultFind(userId);
+            Long savedId = findService.join(findRequest);
+
+            UpdateFindRequest updateRequest = UpdateFindRequest.builder()
+                    .title("바지 찾아봅니다")
+                    .image("image.png")
+                    .text("안 입는 바지 기부받아요")
+                    .tag(String.valueOf(Tag.PANTS))
+                    .findId(userId)
+                    .build();
+
+            // when
+            findService.updateAll(savedId, updateRequest);
+            Find updateFind = findService.findById(savedId);
+
+            // then
+            assertEquals("바지 찾아봅니다", updateFind.getTitle());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 게시글을 수정시 예외가 발생해야 한다.")
+        void update_post_fail() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateFindRequest findRequest = createDefaultFind(userId);
+            findService.join(findRequest);
+
+            UpdateFindRequest updateRequest = UpdateFindRequest.builder()
+                    .title("바지 찾아봅니다")
+                    .image("image.png")
+                    .text("안 입는 바지 기부받아요")
+                    .tag(String.valueOf(Tag.PANTS))
+                    .findId(userId)
+                    .build();
+
+            // when
+
+            // then
+            assertThrows(PostNotFoundException.class, () -> findService.updateAll(100L, updateRequest));
+        }
     }
 
-    @Test
-    public void 전체_게시글_최근순_조회_페이징() throws Exception {
+    @Nested
+    @DisplayName("게시글 삭제 테스트")
+    class DeletePost {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateUserRequest request2 = new CreateUserRequest("2", "donggwon@gmail.com", "profile.png", 2000, "donggwon", String.valueOf(Role.GENERAL));
-        CreateFindRequest request3 = new CreateFindRequest("패딩 찾아봅니다", "image.png", "안 입는 패딩 기부받아요", String.valueOf(Tag.TOP), 1L);
-        CreateFindRequest request4 = new CreateFindRequest("바지 찾아봅니다", "image.png", "안 입는 바지 기부받아요", String.valueOf(Tag.PANTS), 2L);
-        PageRequest request = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+        @Test
+        @DisplayName("게시글 삭제시 게시글이 삭제되어야 한다.")
+        void delete_post() {
 
-        // when
-        userService.join(request1);
-        userService.join(request2);
-        findService.join(request3);
-        findService.join(request4);
-        List<Find> finds = findService.findByCreatedDateDescUsingPaging(request).getContent();
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(request4.title(), finds.get(0).getTitle());
-    }
+            CreateFindRequest findRequest = createDefaultFind(userId);
+            Long savedId = findService.join(findRequest);
 
-    @Test
-    public void 전체_게시글_태그별_조회() throws Exception {
+            // when
+            findService.deleteFind(savedId);
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateFindRequest request2 = new CreateFindRequest("패딩 찾아봅니다", "image.png", "안 입는 패딩 기부받아요", String.valueOf(Tag.TOP), 1L);
-        CreateFindRequest request3 = new CreateFindRequest("청바지 찾아봅니다", "image.png", "안 입는 바지 기부받아요", String.valueOf(Tag.PANTS), 1L);
-        CreateFindRequest request4 = new CreateFindRequest("트레이닝 바지 찾아봅니다", "image.png", "안 입는 바지 기부받아요", String.valueOf(Tag.PANTS), 1L);
+            // then
+            assertThrows(PostNotFoundException.class, () -> findService.findById(savedId));
+        }
 
-        // when
-        userService.join(request1);
-        findService.join(request2);
-        findService.join(request3);
-        findService.join(request4);
-        List<Find> byTag = findService.findByTag(Tag.PANTS);
+        @Test
+        @DisplayName("존재하지 않는 게시글을 삭제시 예외가 발생해야 한다.")
+        void delete_post_fail() {
 
-        // then
-        assertEquals(2, byTag.size());
-    }
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-    @Test
-    public void 게시글_전체_수정() throws Exception {
+            CreateFindRequest findRequest = createDefaultFind(userId);
+            Long savedId = findService.join(findRequest);
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateFindRequest request2 = new CreateFindRequest("패딩 찾아봅니다", "image.png", "안 입는 패딩 기부받아요", String.valueOf(Tag.TOP), 1L);
+            // when
 
-        // when
-        userService.join(request1);
-        Long findId = findService.join(request2);
-
-        UpdateFindRequest updateRequest = new UpdateFindRequest("바지 찾아봅니다", "image.png", "안 입는 바지 기부받아요", String.valueOf(Tag.PANTS), 1L);
-        findService.updateAll(findId, updateRequest);
-        Find updateFind = findService.findById(findId);
-
-        // then
-        assertEquals("바지 찾아봅니다", updateFind.getTitle());
-        System.out.println(updateFind.getView()); // 조회수 확인
-    }
-
-    @Test
-    public void 게시글_삭제() throws Exception {
-
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateFindRequest request2 = new CreateFindRequest("패딩 찾아봅니다", "image.png", "안 입는 패딩 기부받아요", String.valueOf(Tag.TOP), 1L);
-
-        // when
-        userService.join(request1);
-        Long findId = findService.join(request2);
-
-        findService.deleteFind(findId);
-
-        // then
-        assertThrows(PostNotFoundException.class, () -> findService.findById(findId));
+            // then
+            assertThrows(PostNotFoundException.class, () -> findService.deleteFind(100L));
+        }
     }
 }

--- a/src/test/java/io/wisoft/capstonedesign/service/InformationServiceTest.java
+++ b/src/test/java/io/wisoft/capstonedesign/service/InformationServiceTest.java
@@ -4,10 +4,13 @@ import io.wisoft.capstonedesign.domain.information.application.InformationServic
 import io.wisoft.capstonedesign.domain.information.persistence.Information;
 import io.wisoft.capstonedesign.domain.information.web.dto.CreateInformationRequest;
 import io.wisoft.capstonedesign.domain.information.web.dto.UpdateInformationRequest;
+import io.wisoft.capstonedesign.domain.user.application.UserService;
 import io.wisoft.capstonedesign.domain.user.web.dto.CreateUserRequest;
 import io.wisoft.capstonedesign.global.enumerated.Role;
-import io.wisoft.capstonedesign.domain.user.application.UserService;
 import io.wisoft.capstonedesign.global.exception.service.InfoNotFoundException;
+import io.wisoft.capstonedesign.global.exception.service.UserNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,6 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static io.wisoft.capstonedesign.setting.data.DefaultInfoData.createDefaultInfo;
+import static io.wisoft.capstonedesign.setting.data.DefaultUserData.createDefaultUser;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
@@ -26,121 +31,276 @@ public class InformationServiceTest {
     @Autowired InformationService informationService;
     @Autowired UserService userService;
 
-    @Test
-    public void 배송정보_생성() throws Exception {
+    @Nested
+    @DisplayName("배송정보 생성 테스트")
+    class CreateInfo {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateInformationRequest request2 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
+        @Test
+        @DisplayName("배송정보 입력시 정상적으로 저장되어야 한다.")
+        void create_info() {
 
-        // when
-        userService.join(request1);
-        Long savedId = informationService.save(request2);
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(request2.address(), informationService.findById(savedId).getAddress());
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+
+            // when
+            Long savedId = informationService.save(infoRequest);
+
+            // then
+            Information information = informationService.findById(savedId);
+            assertEquals("대전광역시 유성구", information.getAddress());
+        }
+
+        @Test
+        @DisplayName("회원이 아닌 사용자가 배송정보 입력시 예외가 발생해야 한다.")
+        void create_info_fail() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            userService.join(userRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(100L);
+
+            // when
+
+            // then
+            assertThrows(UserNotFoundException.class, () -> informationService.save(infoRequest));
+        }
     }
 
-    @Test
-    public void 회원별_배송정보_조회() throws Exception {
+    @Nested
+    @DisplayName("배송정보 조회 테스트")
+    class FindInfo {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateUserRequest request2 = new CreateUserRequest("2", "donggwon@gmail.com", "profile.png", 1000, "donggwon", String.valueOf(Role.GENERAL));
-        CreateInformationRequest request3 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateInformationRequest request4 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateInformationRequest request5 = new CreateInformationRequest("서동권", "대전광역시 덕명동", "010-1111-1111", 2L);
+        @Test
+        @DisplayName("배송정보 단건 조회 요청시 한 게시글이 조회되어야 한다.")
+        void find_single_info() {
 
-        // when
-        Long userId = userService.join(request1);
-        userService.join(request2);
-        informationService.save(request3);
-        informationService.save(request4);
-        informationService.save(request5);
-        List<Information> savedInfo = informationService.findByUser(userId);
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(2, savedInfo.size());
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long savedId = informationService.save(infoRequest);
+
+            // when
+            Information savedInfo = informationService.findById(savedId);
+
+            // then
+            assertEquals("윤진원", savedInfo.getUsername());
+            assertEquals("대전광역시 유성구", savedInfo.getAddress());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 배송정보를 조회시 예외가 발생해야 한다.")
+        void find_single_info_fail() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            informationService.save(infoRequest);
+
+            // when
+
+            // then
+            assertThrows(InfoNotFoundException.class, () -> informationService.findById(100L));
+        }
+
+        @Test
+        @DisplayName("회원별 배송정보 조회시 회원에 맞는 배송정보가 반환되어야 한다.")
+        void find_info_by_user() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateUserRequest request2 = CreateUserRequest.builder()
+                    .oauthId("2")
+                    .email("donggwon@gmail.com")
+                    .profileImage("profile.png")
+                    .point(1000)
+                    .nickname("donggwon")
+                    .userRole(String.valueOf(Role.GENERAL))
+                    .build();
+            Long userId2 = userService.join(request2);
+
+            CreateInformationRequest infoRequest1 = createDefaultInfo(userId);
+            informationService.save(infoRequest1);
+
+            CreateInformationRequest infoRequest2 = CreateInformationRequest.builder()
+                    .username("윤진원")
+                    .address("대전광역시 서구")
+                    .phoneNumber("010-0000-0000")
+                    .userId(userId)
+                    .build();
+            informationService.save(infoRequest2);
+
+            CreateInformationRequest infoRequest3 = CreateInformationRequest.builder()
+                    .username("서동권")
+                    .address("대전광역시 서구")
+                    .phoneNumber("010-0000-0000")
+                    .userId(userId2)
+                    .build();
+            informationService.save(infoRequest3);
+
+            // when
+            List<Information> byUser = informationService.findByUser(userId);
+
+            // then
+            assertEquals(2L, byUser.size());
+        }
+
+        @Test
+        @DisplayName("전체 배송정보 조회시 전체 게시글 목록을 반환해야 한다.")
+        void find_infos() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateInformationRequest infoRequest1 = createDefaultInfo(userId);
+            informationService.save(infoRequest1);
+
+            CreateInformationRequest infoRequest2 = CreateInformationRequest.builder()
+                    .username("윤진원")
+                    .address("대전광역시 서구")
+                    .phoneNumber("010-0000-0000")
+                    .userId(userId)
+                    .build();
+            informationService.save(infoRequest2);
+
+            // when
+            List<Information> informations = informationService.findInformations();
+
+            // then
+            assertEquals(2, informations.size());
+            assertEquals("대전광역시 유성구", informations.get(0).getAddress());
+        }
+
+        @Test
+        @DisplayName("전체 게시글을 페이징을 사용하여 조회시 페이지 번호와 내림차순으로 정렬된 페이지가 반환되어야 한다.")
+        void find_infos_using_paging() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateInformationRequest infoRequest1 = createDefaultInfo(userId);
+            informationService.save(infoRequest1);
+
+            CreateInformationRequest infoRequest2 = CreateInformationRequest.builder()
+                    .username("윤진원")
+                    .address("대전광역시 서구")
+                    .phoneNumber("010-0000-0000")
+                    .userId(userId)
+                    .build();
+            informationService.save(infoRequest2);
+            PageRequest request = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+
+            // when
+            List<Information> informationList = informationService.findByCreatedDateDescUsingPaging(request).getContent();
+
+            // then
+            assertEquals("대전광역시 서구", informationList.get(0).getAddress());
+        }
     }
 
-    @Test
-    public void 전체_배송정보_조회() throws Exception {
+    @Nested
+    @DisplayName("배송정보 수정 테스트")
+    class UpdateInfo {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateUserRequest request2 = new CreateUserRequest("2", "donggwon@gmail.com", "profile.png", 1000, "donggwon", String.valueOf(Role.GENERAL));
-        CreateInformationRequest request3 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateInformationRequest request4 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateInformationRequest request5 = new CreateInformationRequest("서동권", "대전광역시 덕명동", "010-1111-1111", 2L);
+        @Test
+        @DisplayName("배송정보 수정시 배송정보가 수정되어야 한다.")
+        void update_info() {
 
-        // when
-        userService.join(request1);
-        userService.join(request2);
-        informationService.save(request3);
-        informationService.save(request4);
-        informationService.save(request5);
-        List<Information> informations = informationService.findInformations();
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(3, informations.size());
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long savedId = informationService.save(infoRequest);
+
+            UpdateInformationRequest updateRequest = UpdateInformationRequest.builder()
+                    .username("윤진원")
+                    .address("대전광역시 서구")
+                    .phoneNumber("010-0000-0000")
+                    .infoId(savedId)
+                    .build();
+
+            // when
+            informationService.updateAll(savedId, updateRequest);
+            Information updateInfo = informationService.findById(savedId);
+
+            // then
+            assertEquals("대전광역시 서구", updateInfo.getAddress());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 배송정보를 수정시 예외가 발생해야 한다.")
+        void update_info_fail() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long savedId = informationService.save(infoRequest);
+
+            UpdateInformationRequest updateRequest = UpdateInformationRequest.builder()
+                    .username("윤진원")
+                    .address("대전광역시 서구")
+                    .phoneNumber("010-0000-0000")
+                    .infoId(savedId)
+                    .build();
+
+            // when
+
+            // then
+            assertThrows(InfoNotFoundException.class, () -> informationService.updateAll(100L, updateRequest));
+        }
     }
 
-    @Test
-    public void 전체_배송정보_조회_페이징() throws Exception {
+    @Nested
+    @DisplayName("배송정보 삭제 테스트")
+    class DeleteInfo {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateUserRequest request2 = new CreateUserRequest("2", "donggwon@gmail.com", "profile.png", 1000, "donggwon", String.valueOf(Role.GENERAL));
-        CreateInformationRequest request3 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateInformationRequest request4 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateInformationRequest request5 = new CreateInformationRequest("서동권", "대전광역시 덕명동", "010-1111-1111", 2L);
-        PageRequest request = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+        @Test
+        @DisplayName("배송정보 삭제시 배송정보가 삭제되어야 한다.")
+        void delete_info() {
 
-        // when
-        userService.join(request1);
-        userService.join(request2);
-        informationService.save(request3);
-        informationService.save(request4);
-        informationService.save(request5);
-        List<Information> informations = informationService.findByCreatedDateDescUsingPaging(request).getContent();
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(request5.username(), informations.get(0).getUsername());
-    }
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long savedId = informationService.save(infoRequest);
 
-    @Test
-    public void 배송정보_전체_수정() throws Exception {
+            // when
+            informationService.deleteInformation(savedId);
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateInformationRequest request2 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
+            // then
+            assertThrows(InfoNotFoundException.class, () -> informationService.findById(savedId));
+        }
 
-        // when
-        userService.join(request1);
-        Long savedId = informationService.save(request2);
+        @Test
+        @DisplayName("존재하지 않는 배송정보를 삭제시 예외가 발생해야 한다.")
+        void delete_info_fail() {
 
-        UpdateInformationRequest updateRequest = new UpdateInformationRequest("윤진원", "대전광역시 서구", "010-1111-1111", 1L);
-        informationService.updateAll(savedId, updateRequest);
-        Information updateInfo = informationService.findById(savedId);
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals("대전광역시 서구", updateInfo.getAddress());
-    }
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            informationService.save(infoRequest);
 
-    @Test
-    public void 배송정보_삭제() throws Exception {
+            // when
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateInformationRequest request2 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-
-        // when
-        userService.join(request1);
-        Long savedId = informationService.save(request2);
-
-        informationService.deleteInformation(savedId);
-
-        // then
-        assertThrows(InfoNotFoundException.class, () -> informationService.findById(savedId));
+            // then
+            assertThrows(InfoNotFoundException.class, () -> informationService.deleteInformation(100L));
+        }
     }
 }

--- a/src/test/java/io/wisoft/capstonedesign/service/ShopServiceTest.java
+++ b/src/test/java/io/wisoft/capstonedesign/service/ShopServiceTest.java
@@ -1,13 +1,15 @@
 package io.wisoft.capstonedesign.service;
 
-import io.wisoft.capstonedesign.domain.shop.web.dto.CreateShopRequest;
-import io.wisoft.capstonedesign.domain.shop.web.dto.UpdateShopRequest;
-import io.wisoft.capstonedesign.domain.user.web.dto.CreateUserRequest;
-import io.wisoft.capstonedesign.global.enumerated.Role;
 import io.wisoft.capstonedesign.domain.shop.application.ShopService;
 import io.wisoft.capstonedesign.domain.shop.persistence.Shop;
+import io.wisoft.capstonedesign.domain.shop.web.dto.CreateShopRequest;
+import io.wisoft.capstonedesign.domain.shop.web.dto.UpdateShopRequest;
 import io.wisoft.capstonedesign.domain.user.application.UserService;
+import io.wisoft.capstonedesign.domain.user.web.dto.CreateUserRequest;
 import io.wisoft.capstonedesign.global.exception.service.PostNotFoundException;
+import io.wisoft.capstonedesign.global.exception.service.UserNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,7 +19,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static io.wisoft.capstonedesign.setting.data.DefaultShopData.createDefaultShop;
+import static io.wisoft.capstonedesign.setting.data.DefaultUserData.createDefaultUser;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Transactional
@@ -26,106 +31,265 @@ public class ShopServiceTest {
     @Autowired ShopService shopService;
     @Autowired UserService userService;
 
-    @Test
-    public void 산타샵_물품_생성() throws Exception {
+    @Nested
+    @DisplayName("산타샵 물품 생성 테스트")
+    class CreateProduct {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateShopRequest request2 = new CreateShopRequest("라면 한 박스", 1000, "ramen.jpg", "포인트로 뜨끈한 라면 한 박스 가져가세요!", 1L);
+        @Test
+        @DisplayName("산타샵 물품 생성시 정상적으로 생성되어야 한다,")
+        void create_product() {
 
-        // when
-        userService.join(request1);
-        Long savedId = shopService.save(request2);
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(request2.title(), shopService.findById(savedId).getTitle());
+            CreateShopRequest shopRequest = createDefaultShop(userId);
+
+            // when
+            Long savedId = shopService.save(shopRequest);
+
+            // then
+            Shop shop = shopService.findById(savedId);
+            assertEquals("라면 한 박스", shop.getTitle());
+        }
+
+        @Test
+        @DisplayName("회원이 아닌 사용자가 물품 생성시 예외가 발생해야 한다,")
+        void create_product_fail() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            userService.join(userRequest);
+
+            CreateShopRequest shopRequest = createDefaultShop(100L);
+
+            // when
+
+            // then
+            assertThrows(UserNotFoundException.class, () -> shopService.save(shopRequest));
+        }
     }
 
-    @Test
-    public void 전체_산타샵_물품조회() throws Exception {
+    @Nested
+    @DisplayName("산타샵 물품 조회 테스트")
+    class FindProduct {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateShopRequest request2 = new CreateShopRequest("라면 한 박스", 1000, "ramen.jpg", "포인트로 뜨끈한 라면 한 박스 가져가세요!", 1L);
-        CreateShopRequest request3 = new CreateShopRequest("쌀 10kg", 2000, "rice.jpg", "포인트로 든든한 쌀 밥 가져가세요!", 1L);
+        @Test
+        @DisplayName("물품 단건 조회 요청시 한 물품이 조회되어야 한다.")
+        void find_single_product() {
 
-        // when
-        userService.join(request1);
-        shopService.save(request2);
-        shopService.save(request3);
-        List<Shop> shopList = shopService.findShopList();
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(2, shopList.size());
+            CreateShopRequest shopRequest = createDefaultShop(userId);
+            Long savedId = shopService.save(shopRequest);
+
+            // when
+            Shop savedShop = shopService.findById(savedId);
+
+            // then
+            assertEquals("라면 한 박스", savedShop.getTitle());
+            assertEquals("포인트로 뜨끈한 라면 한 박스 가져가세요!", savedShop.getBody());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 물품을 조회시 예외가 발생해야 한다.")
+        void find_single_product_fail() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateShopRequest shopRequest = createDefaultShop(userId);
+            shopService.save(shopRequest);
+
+            // when
+
+            // then
+            assertThrows(PostNotFoundException.class, () -> shopService.findById(100L));
+        }
+
+        @Test
+        @DisplayName("전체 산타샵 물품 조회시 전체 물품 목록을 반환해야 한다.")
+        void find_shop_products() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateShopRequest shopRequest1 = createDefaultShop(userId);
+            shopService.save(shopRequest1);
+
+            CreateShopRequest shopRequest2 = CreateShopRequest.builder()
+                    .title("쌀 10kg")
+                    .price(2000)
+                    .image("rice.jpg")
+                    .body("포인트로 든든한 쌀 밥 가져가세요!")
+                    .userId(userId)
+                    .build();
+            shopService.save(shopRequest2);
+
+            // when
+            List<Shop> shopList = shopService.findShopList();
+
+            // then
+            assertEquals(2, shopList.size());
+            assertEquals("라면 한 박스", shopList.get(0).getTitle());
+        }
+
+        @Test
+        @DisplayName("산타샵 물품 이름으로 조회시 이름에 맞는 물품을 반환한다.")
+        void find_product_by_name() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateShopRequest shopRequest = createDefaultShop(userId);
+            Long savedId = shopService.save(shopRequest);
+
+            Shop shop = shopService.findById(savedId);
+
+            // when
+            List<Shop> shopByTitle = shopService.findShopByTitle(shop.getTitle());
+
+            // then
+            assertEquals("라면 한 박스", shopByTitle.get(0).getTitle());
+        }
+
+        @Test
+        @DisplayName("전체 물품을 페이징을 사용하여 조회시 페이지 번호와 내림차순으로 정렬된 페이지가 반환되어야 한다.")
+        void find_products_using_paging() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateShopRequest shopRequest1 = createDefaultShop(userId);
+            shopService.save(shopRequest1);
+
+            CreateShopRequest shopRequest2 = CreateShopRequest.builder()
+                    .title("쌀 10kg")
+                    .price(2000)
+                    .image("rice.jpg")
+                    .body("포인트로 든든한 쌀 밥 가져가세요!")
+                    .userId(userId)
+                    .build();
+            shopService.save(shopRequest2);
+
+            CreateShopRequest shopRequest3 = CreateShopRequest.builder()
+                    .title("휴지 20롤")
+                    .price(3000)
+                    .image("paper.jpg")
+                    .body("포인트로 떨어진 휴지 챙겨가세요!")
+                    .userId(userId)
+                    .build();
+            shopService.save(shopRequest3);
+            PageRequest request = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+
+            // when
+            List<Shop> shopList = shopService.findByCreatedDateDescUsingPaging(request).getContent();
+
+            // then
+            assertEquals("휴지 20롤", shopList.get(0).getTitle());
+        }
     }
 
-    @Test
-    public void 물품_이름으로_조회() throws Exception {
+    @Nested
+    @DisplayName("산타샵 물품 수정 테스트")
+    class UpdateProduct {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateShopRequest request2 = new CreateShopRequest("라면 한 박스", 1000, "ramen.jpg", "포인트로 뜨끈한 라면 한 박스 가져가세요!", 1L);
+        @Test
+        @DisplayName("산타샵 물품 수정시 물품이 수정되어야 한다.")
+        void update_product() {
 
-        // when
-        userService.join(request1);
-        shopService.save(request2);
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals("라면 한 박스", request2.title());
+            CreateShopRequest shopRequest = createDefaultShop(userId);
+            Long savedId = shopService.save(shopRequest);
+
+            UpdateShopRequest updateRequest = UpdateShopRequest.builder()
+                    .title("쌀 10kg")
+                    .price(2000)
+                    .image("rice.jpg")
+                    .body("포인트로 든든한 쌀 밥 가져가세요!")
+                    .shopId(savedId)
+                    .build();
+
+            // when
+            shopService.updateAll(savedId, updateRequest);
+            Shop updateShop = shopService.findById(savedId);
+
+            // then
+            assertEquals("쌀 10kg", updateShop.getTitle());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 물품을 수정시 예외가 발생해야 한다.")
+        void update_product_fail() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateShopRequest shopRequest = createDefaultShop(userId);
+            Long savedId = shopService.save(shopRequest);
+
+            UpdateShopRequest updateRequest = UpdateShopRequest.builder()
+                    .title("쌀 10kg")
+                    .price(2000)
+                    .image("rice.jpg")
+                    .body("포인트로 든든한 쌀 밥 가져가세요!")
+                    .shopId(savedId)
+                    .build();
+
+            // when
+
+            // then
+            assertThrows(PostNotFoundException.class, () -> shopService.updateAll(100L, updateRequest));
+        }
     }
 
-    @Test
-    public void 전체물품_최근순_조회() throws Exception {
+    @Nested
+    @DisplayName("산타샵 물품 삭제 테스트")
+    class DeleteProduct {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateShopRequest request2 = new CreateShopRequest("라면 한 박스", 1000, "ramen.jpg", "포인트로 뜨끈한 라면 한 박스 가져가세요!", 1L);
-        CreateShopRequest request3 = new CreateShopRequest("쌀 10kg", 2000, "rice.jpg", "포인트로 든든한 쌀 밥 가져가세요!", 1L);
-        PageRequest request = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+        @Test
+        @DisplayName("산타샵 물품 삭제시 물품이 삭제되어야 한다.")
+        void delete_product() {
 
-        // when
-        userService.join(request1);
-        shopService.save(request2);
-        shopService.save(request3);
-        List<Shop> shops = shopService.findByCreatedDateDescUsingPaging(request).getContent();
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(request3.title(), shops.get(0).getTitle());
-    }
+            CreateShopRequest shopRequest = createDefaultShop(userId);
+            Long savedId = shopService.save(shopRequest);
 
-    @Test
-    public void 물품_전체_수정() throws Exception {
+            // when
+            shopService.deleteShop(savedId);
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateShopRequest request2 = new CreateShopRequest("라면 한 박스", 1000, "ramen.jpg", "포인트로 뜨끈한 라면 한 박스 가져가세요!", 1L);
+            // then
+            assertThrows(PostNotFoundException.class, () -> shopService.findById(savedId));
+        }
 
-        // when
-        userService.join(request1);
-        Long savedId = shopService.save(request2);
+        @Test
+        @DisplayName("존재하지 않는 물품을 삭제시 예외가 발생해야 한다.")
+        void delete_product_fail() {
 
-        UpdateShopRequest updateRequest = new UpdateShopRequest("쌀 10kg", 2000, "rice.png", "포인트로 든든한 쌀 밥 가져가세요!", 1L);
-        shopService.updateAll(savedId, updateRequest);
-        Shop updateShop = shopService.findById(savedId);
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(2000, updateShop.getPrice());
-    }
+            CreateShopRequest shopRequest = createDefaultShop(userId);
+            Long savedId = shopService.save(shopRequest);
 
-    @Test
-    public void 물품_삭제() throws Exception {
+            // when
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateShopRequest request2 = new CreateShopRequest("라면 한 박스", 1000, "ramen.jpg", "포인트로 뜨끈한 라면 한 박스 가져가세요!", 1L);
-
-        // when
-        userService.join(request1);
-        Long savedId = shopService.save(request2);
-
-        shopService.deleteShop(savedId);
-
-        // then
-        assertThrows(PostNotFoundException.class, () -> shopService.findById(savedId));
+            // then
+            assertThrows(PostNotFoundException.class, () -> shopService.deleteShop(100L));
+        }
     }
 }

--- a/src/test/java/io/wisoft/capstonedesign/service/UserMyInfoServiceTest.java
+++ b/src/test/java/io/wisoft/capstonedesign/service/UserMyInfoServiceTest.java
@@ -23,7 +23,11 @@ import io.wisoft.capstonedesign.domain.usershop.application.UserShopService;
 import io.wisoft.capstonedesign.domain.usershop.persistence.UserShop;
 import io.wisoft.capstonedesign.global.enumerated.Role;
 import io.wisoft.capstonedesign.global.enumerated.Tag;
+import io.wisoft.capstonedesign.setting.data.DefaultFindOrderData;
+import io.wisoft.capstonedesign.setting.data.DefaultShopOrderData;
 import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -32,7 +36,13 @@ import org.springframework.data.domain.Sort;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static io.wisoft.capstonedesign.setting.data.DefaultDonateData.createDefaultDonate;
+import static io.wisoft.capstonedesign.setting.data.DefaultDonateOrderData.createDefaultOrder;
+import static io.wisoft.capstonedesign.setting.data.DefaultFindData.createDefaultFind;
+import static io.wisoft.capstonedesign.setting.data.DefaultInfoData.createDefaultInfo;
+import static io.wisoft.capstonedesign.setting.data.DefaultShopData.createDefaultShop;
+import static io.wisoft.capstonedesign.setting.data.DefaultUserData.createDefaultUser;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @Transactional
@@ -48,129 +58,308 @@ public class UserMyInfoServiceTest {
     @Autowired ShopService shopService;
     @Autowired UserShopService userShopService;
 
-    @Test
-    public void 마이페이지_나눠줄래요_게시글조회() throws Exception {
+    @Nested
+    @DisplayName("마이페이지 정보 조회 테스트")
+    class FindMyPageInfo {
 
-        // given
-        CreateUserRequest userRequest = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateDonateRequest donateRequest1 = new CreateDonateRequest("패딩 나눔합니다", "image.png", "안 입는 패딩 기부해요", String.valueOf(Tag.TOP), 1L);
-        CreateDonateRequest donateRequest2 = new CreateDonateRequest("바지 나눔합니다", "image.png", "안 입는 바지 기부해요", String.valueOf(Tag.PANTS), 1L);
-        PageRequest request = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+        @Test
+        @DisplayName("자신이 작성한 나눠줄래요 개시글 조회")
+        void find_my_donate_posts() {
 
-        // when
-        userService.join(userRequest);
-        donateService.join(donateRequest1);
-        donateService.join(donateRequest2);
-        List<Donate> donates = userMyInfoService.findDonatesByIdUsingPaging(1L, request).getContent();
+            // given
+            CreateUserRequest userRequest1 = createDefaultUser();
+            Long userId = userService.join(userRequest1);
 
-        // then
-        assertEquals(donates.get(0).getText(), donateRequest2.text());
-    }
+            CreateUserRequest userRequest2 = CreateUserRequest.builder()
+                    .oauthId("2")
+                    .email("donggwon@gmail.com")
+                    .profileImage("profile.png")
+                    .point(1000)
+                    .nickname("donggwon")
+                    .userRole(String.valueOf(Role.GENERAL))
+                    .build();
+            Long userId2 = userService.join(userRequest2);
 
-    @Test
-    public void 마이페이지_찾아볼래요_게시글조회() throws Exception {
+            CreateDonateRequest donateRequest1 = createDefaultDonate(userId);
+            donateService.join(donateRequest1);
 
-        // given
-        CreateUserRequest userRequest = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateFindRequest findRequest1 = new CreateFindRequest("패딩 찾아봅니다", "image.png", "안 입는 패딩 기부받아요", String.valueOf(Tag.TOP), 1L);
-        CreateFindRequest findRequest2 = new CreateFindRequest("바지 찾아봅니다", "image.png", "안 입는 바지 기부받아요", String.valueOf(Tag.PANTS), 1L);
-        PageRequest request = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+            CreateDonateRequest donateRequest2 = CreateDonateRequest.builder()
+                    .title("바지 나눔합니다")
+                    .image("image.png")
+                    .text("안 입는 바지 기부해요")
+                    .tag(String.valueOf(Tag.PANTS))
+                    .userId(userId2)
+                    .build();
+            donateService.join(donateRequest2);
 
-        // when
-        userService.join(userRequest);
-        findService.join(findRequest1);
-        findService.join(findRequest2);
-        List<Find> finds = userMyInfoService.findFindsByIdUsingPaging(1L, request).getContent();
+            PageRequest request = PageRequest.of(0, 5, Sort.by("createdDate").descending());
 
-        // then
-        assertEquals(finds.get(0).getText(), findRequest2.text());
-    }
+            // when
+            List<Donate> donates = userMyInfoService.findDonatesByIdUsingPaging(userId, request).getContent();
 
-    @Test
-    public void 마이페이지_배송정보조회() throws Exception {
+            // then
+            assertEquals("패딩 나눔합니다.", donates.get(0).getTitle());
+        }
 
-        // given
-        CreateUserRequest userRequest = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateInformationRequest infoRequest1 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateInformationRequest infoRequest2 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        PageRequest request = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+        @Test
+        @DisplayName("자신이 작성한 찾아볼래요 게시글 조회")
+        void find_my_find_posts() {
 
-        // when
-        userService.join(userRequest);
-        informationService.save(infoRequest1);
-        informationService.save(infoRequest2);
-        List<Information> infos = userMyInfoService.findInfosByIdUsingPaging(1L, request).getContent();
+            // given
+            CreateUserRequest userRequest1 = createDefaultUser();
+            Long userId = userService.join(userRequest1);
 
-        // then
-        assertEquals(infos.get(0).getAddress(), infoRequest2.address());
-    }
+            CreateUserRequest userRequest2 = CreateUserRequest.builder()
+                    .oauthId("2")
+                    .email("donggwon@gmail.com")
+                    .profileImage("profile.png")
+                    .point(1000)
+                    .nickname("donggwon")
+                    .userRole(String.valueOf(Role.GENERAL))
+                    .build();
+            Long userId2 = userService.join(userRequest2);
 
-    @Test
-    public void 마이페이지_나눠줄래요_거래내역() throws Exception {
+            CreateFindRequest findRequest1 = createDefaultFind(userId);
+            findService.join(findRequest1);
 
-        // given
-        CreateUserRequest userRequest = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateDonateRequest donateRequest = new CreateDonateRequest("패딩 나눔합니다", "image.png", "안 입는 패딩 기부해요", String.valueOf(Tag.TOP), 1L);
-        CreateInformationRequest infoRequest = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateOrderRequest orderRequest1 = new CreateOrderRequest("배송전 문자주세요", 1L, 1L, 1L);
-        CreateOrderRequest orderRequest2 = new CreateOrderRequest("경비실에 맡겨주세요", 1L, 1L, 1L);
-        PageRequest request = PageRequest.of(0, 5, Sort.by("sendDate").descending());
+            CreateFindRequest findRequest2 = CreateFindRequest.builder()
+                    .title("바지 찾아봅니다")
+                    .image("image.png")
+                    .text("안 입는 바지 기부받아요")
+                    .tag(String.valueOf(Tag.PANTS))
+                    .userId(userId2)
+                    .build();
+            findService.join(findRequest2);
 
-        // when
-        userService.join(userRequest);
-        donateService.join(donateRequest);
-        informationService.save(infoRequest);
-        donateOrderService.save(orderRequest1);
-        donateOrderService.save(orderRequest2);
-        List<DonateOrder> orders = userMyInfoService.findDonateOrdersByIdUsingPaging(1L, request).getContent();
+            PageRequest request = PageRequest.of(0, 5, Sort.by("createdDate").descending());
 
-        // then
-        assertEquals(orders.get(0).getText(), orderRequest2.text());
-    }
+            // when
+            List<Find> finds = userMyInfoService.findFindsByIdUsingPaging(userId, request).getContent();
 
-    @Test
-    public void 마이페이지_찾아볼래요_거래내역() throws Exception {
+            // then
+            assertEquals("패딩 찾아봅니다", finds.get(0).getTitle());
+        }
 
-        // given
-        CreateUserRequest userRequest = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateFindRequest findRequest = new CreateFindRequest("패딩 찾아봅니다", "image.png", "안 입는 패딩 기부받아요", String.valueOf(Tag.TOP), 1L);
-        CreateInformationRequest infoRequest = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        io.wisoft.capstonedesign.domain.findorder.web.dto.CreateOrderRequest orderRequest1 = new io.wisoft.capstonedesign.domain.findorder.web.dto.CreateOrderRequest("배송전 문자주세요", 1L, 1L, 1L);
-        io.wisoft.capstonedesign.domain.findorder.web.dto.CreateOrderRequest orderRequest2 = new io.wisoft.capstonedesign.domain.findorder.web.dto.CreateOrderRequest("경비실에 맡겨주세요", 1L, 1L, 1L);
-        PageRequest request = PageRequest.of(0, 5, Sort.by("sendDate").descending());
+        @Test
+        @DisplayName("자신이 작성한 배송정보 조회")
+        void find_my_infos() {
 
-        // when
-        userService.join(userRequest);
-        findService.join(findRequest);
-        informationService.save(infoRequest);
-        findOrderService.save(orderRequest1);
-        findOrderService.save(orderRequest2);
-        List<FindOrder> orders = userMyInfoService.findFindOrdersByIdUsingPaging(1L, request).getContent();
+            // given
+            CreateUserRequest userRequest1 = createDefaultUser();
+            Long userId = userService.join(userRequest1);
 
-        // then
-        assertEquals(orders.get(0).getText(), orderRequest2.text());
-    }
+            CreateUserRequest userRequest2 = CreateUserRequest.builder()
+                    .oauthId("2")
+                    .email("donggwon@gmail.com")
+                    .profileImage("profile.png")
+                    .point(1000)
+                    .nickname("donggwon")
+                    .userRole(String.valueOf(Role.GENERAL))
+                    .build();
+            Long userId2 = userService.join(userRequest2);
 
-    @Test
-    public void 마이페이지_산타샵_주문내역() throws Exception {
+            CreateInformationRequest infoRequest1 = createDefaultInfo(userId);
+            informationService.save(infoRequest1);
 
-        // given
-        CreateUserRequest userRequest = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateShopRequest shopRequest = new CreateShopRequest("라면 한 박스", 1000, "ramen.jpg", "포인트로 뜨끈한 라면 한 박스 가져가세요!", 1L);
-        CreateInformationRequest inforRequest = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        io.wisoft.capstonedesign.domain.usershop.web.dto.CreateOrderRequest orderRequest1 = new io.wisoft.capstonedesign.domain.usershop.web.dto.CreateOrderRequest("배송 전 문자 부탁드립니다", 1L, 1L, 1L);
-        io.wisoft.capstonedesign.domain.usershop.web.dto.CreateOrderRequest orderRequest2 = new io.wisoft.capstonedesign.domain.usershop.web.dto.CreateOrderRequest("경비실에 맡겨주세요", 1L, 1L, 1L);
-        PageRequest request = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+            CreateInformationRequest infoRequest2 = CreateInformationRequest.builder()
+                    .username("서동권")
+                    .address("대전광역시 서구")
+                    .phoneNumber("010-0000-0000")
+                    .userId(userId2)
+                    .build();
+            informationService.save(infoRequest2);
 
-        // when
-        userService.join(userRequest);
-        shopService.save(shopRequest);
-        informationService.save(inforRequest);
-        userShopService.save(orderRequest1);
-        userShopService.save(orderRequest2);
-        List<UserShop> shops = userMyInfoService.findShopOrdersByIdUsingPaging(1L, request).getContent();
+            PageRequest request = PageRequest.of(0, 5, Sort.by("createdDate").descending());
 
-        // then
-        assertEquals(shops.get(0).getText(), orderRequest2.text());
+            // when
+            List<Information> infos = userMyInfoService.findInfosByIdUsingPaging(userId, request).getContent();
+
+            // then
+            assertEquals("대전광역시 유성구", infos.get(0).getAddress());
+        }
+
+        @Test
+        @DisplayName("자신이 거래한 나눠줄래요 주문내역 조회")
+        void find_my_donate_orders() {
+
+            // given
+            CreateUserRequest userRequest1 = createDefaultUser();
+            Long userId = userService.join(userRequest1);
+
+            CreateUserRequest userRequest2 = CreateUserRequest.builder()
+                    .oauthId("2")
+                    .email("donggwon@gmail.com")
+                    .profileImage("profile.png")
+                    .point(1000)
+                    .nickname("donggwon")
+                    .userRole(String.valueOf(Role.GENERAL))
+                    .build();
+            Long userId2 = userService.join(userRequest2);
+
+            CreateDonateRequest donateRequest1 = createDefaultDonate(userId);
+            Long donateId = donateService.join(donateRequest1);
+
+            CreateDonateRequest donateRequest2 = CreateDonateRequest.builder()
+                    .title("바지 나눔합니다.")
+                    .image("image.png")
+                    .text("안 입는 바지 기부해요")
+                    .tag(String.valueOf(Tag.PANTS))
+                    .userId(userId2)
+                    .build();
+            donateService.join(donateRequest2);
+
+            CreateInformationRequest infoRequest1 = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest1);
+
+            CreateInformationRequest infoRequest2 = CreateInformationRequest.builder()
+                    .username("서동권")
+                    .address("대전광역시 서구")
+                    .phoneNumber("010-0000-0000")
+                    .userId(userId2)
+                    .build();
+            informationService.save(infoRequest2);
+
+
+            CreateOrderRequest orderRequest1 = createDefaultOrder(infoId, donateId, userId);
+            donateOrderService.save(orderRequest1);
+
+            CreateOrderRequest orderRequest2 = CreateOrderRequest.builder()
+                    .text("경비실에 맡겨주세요")
+                    .infoId(infoId)
+                    .donateId(donateId)
+                    .userId(userId2)
+                    .build();
+            donateOrderService.save(orderRequest2);
+
+            PageRequest request = PageRequest.of(0, 5, Sort.by("sendDate").descending());
+
+            // when
+            List<DonateOrder> orders = userMyInfoService.findDonateOrdersByIdUsingPaging(userId, request).getContent();
+
+            // then
+            assertEquals("배송전 문자주세요", orders.get(0).getText());
+        }
+
+        @Test
+        @DisplayName("자신이 거래한 찾아볼래요 주문내역 조회")
+        void find_my_find_orders() {
+
+            // given
+            CreateUserRequest userRequest1 = createDefaultUser();
+            Long userId = userService.join(userRequest1);
+
+            CreateUserRequest userRequest2 = CreateUserRequest.builder()
+                    .oauthId("2")
+                    .email("donggwon@gmail.com")
+                    .profileImage("profile.png")
+                    .point(1000)
+                    .nickname("donggwon")
+                    .userRole(String.valueOf(Role.GENERAL))
+                    .build();
+            Long userId2 = userService.join(userRequest2);
+
+            CreateFindRequest findRequest1 = createDefaultFind(userId);
+            Long findId = findService.join(findRequest1);
+
+            CreateFindRequest findRequest2 = CreateFindRequest.builder()
+                    .title("바지 찾아봅니다")
+                    .image("image.png")
+                    .text("안 입는 바지 기부받아요")
+                    .tag(String.valueOf(Tag.PANTS))
+                    .userId(userId2)
+                    .build();
+            findService.join(findRequest2);
+
+            CreateInformationRequest infoRequest1 = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest1);
+
+            CreateInformationRequest infoRequest2 = CreateInformationRequest.builder()
+                    .username("서동권")
+                    .address("대전광역시 서구")
+                    .phoneNumber("010-0000-0000")
+                    .userId(userId2)
+                    .build();
+            informationService.save(infoRequest2);
+
+            io.wisoft.capstonedesign.domain.findorder.web.dto.CreateOrderRequest orderRequest1 = DefaultFindOrderData.createDefaultOrder(infoId, findId, userId);
+            findOrderService.save(orderRequest1);
+
+            io.wisoft.capstonedesign.domain.findorder.web.dto.CreateOrderRequest orderRequest2 = io.wisoft.capstonedesign.domain.findorder.web.dto.CreateOrderRequest.builder()
+                    .text("경비실에 맡겨주세요")
+                    .infoId(infoId)
+                    .findId(findId)
+                    .userId(userId2)
+                    .build();
+            findOrderService.save(orderRequest2);
+
+            PageRequest request = PageRequest.of(0, 5, Sort.by("sendDate").descending());
+
+            // when
+            List<FindOrder> orders = userMyInfoService.findFindOrdersByIdUsingPaging(userId, request).getContent();
+
+            // then
+            assertEquals("배송전 문자주세요", orders.get(0).getText());
+        }
+
+        @Test
+        @DisplayName("자산이 주문한 산타샵 주문내역 조회")
+        void find_my_shop_order() {
+
+            // given
+            CreateUserRequest userRequest1 = createDefaultUser();
+            Long userId = userService.join(userRequest1);
+
+            CreateUserRequest userRequest2 = CreateUserRequest.builder()
+                    .oauthId("2")
+                    .email("donggwon@gmail.com")
+                    .profileImage("profile.png")
+                    .point(1000)
+                    .nickname("donggwon")
+                    .userRole(String.valueOf(Role.GENERAL))
+                    .build();
+            Long userId2 = userService.join(userRequest2);
+
+            CreateShopRequest shopRequest1 = createDefaultShop(userId);
+            Long shopId = shopService.save(shopRequest1);
+
+            CreateShopRequest shopRequest2 = CreateShopRequest.builder()
+                    .title("쌀 10kg")
+                    .price(2000)
+                    .image("rice.jpg")
+                    .body("포인트로 든든한 쌀 밥 가져가세요!")
+                    .userId(userId2)
+                    .build();
+            shopService.save(shopRequest2);
+
+            CreateInformationRequest infoRequest1 = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest1);
+
+            CreateInformationRequest infoRequest2 = CreateInformationRequest.builder()
+                    .username("서동권")
+                    .address("대전광역시 서구")
+                    .phoneNumber("010-0000-0000")
+                    .userId(userId2)
+                    .build();
+            informationService.save(infoRequest2);
+
+            io.wisoft.capstonedesign.domain.usershop.web.dto.CreateOrderRequest orderRequest1 = DefaultShopOrderData.createDefaultOrder(infoId, shopId, userId);
+            userShopService.save(orderRequest1);
+
+            io.wisoft.capstonedesign.domain.usershop.web.dto.CreateOrderRequest orderRequest2 = io.wisoft.capstonedesign.domain.usershop.web.dto.CreateOrderRequest.builder()
+                    .text("경비실에 맡겨주세요")
+                    .infoId(infoId)
+                    .shopId(shopId)
+                    .userId(userId2)
+                    .build();
+            userShopService.save(orderRequest2);
+
+            PageRequest request = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+
+            // when
+            List<UserShop> shops = userMyInfoService.findShopOrdersByIdUsingPaging(userId, request).getContent();
+
+            // then
+            assertEquals("배송 전 문자 부탁드립니다", shops.get(0).getText());
+        }
     }
 }

--- a/src/test/java/io/wisoft/capstonedesign/service/UserServiceTest.java
+++ b/src/test/java/io/wisoft/capstonedesign/service/UserServiceTest.java
@@ -1,12 +1,14 @@
 package io.wisoft.capstonedesign.service;
 
+import io.wisoft.capstonedesign.domain.user.application.UserService;
+import io.wisoft.capstonedesign.domain.user.persistence.User;
 import io.wisoft.capstonedesign.domain.user.web.dto.CreateUserRequest;
 import io.wisoft.capstonedesign.domain.user.web.dto.UpdateUserRequest;
 import io.wisoft.capstonedesign.global.enumerated.Role;
-import io.wisoft.capstonedesign.domain.user.application.UserService;
-import io.wisoft.capstonedesign.domain.user.persistence.User;
 import io.wisoft.capstonedesign.global.exception.service.UserDuplicateException;
 import io.wisoft.capstonedesign.global.exception.service.UserNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,7 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static io.wisoft.capstonedesign.setting.data.DefaultUserData.createDefaultUser;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Transactional
@@ -22,91 +26,180 @@ public class UserServiceTest {
 
     @Autowired UserService userService;
 
-    @Test
-    public void 회원가입() throws Exception {
+    @Nested
+    @DisplayName("회원 가입 테스트")
+    class Join {
 
-        // given
-        CreateUserRequest request = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
+        @Test
+        @DisplayName("회원가입시 정상적으로 가입이 되야 한다.")
+        void save_user() {
 
-        // when
-        Long saveId = userService.join(request);
+            // given
+            CreateUserRequest request = createDefaultUser();
 
-        // then
-        assertEquals(request.nickname(), userService.findById(saveId).getNickname());
+            // when
+            Long savedId = userService.join(request);
+
+            // then
+            User user = userService.findById(savedId);
+            assertEquals("jinwon", user.getNickname());
+        }
+
+        @Test
+        @DisplayName("이메일 중복시 회원 가입이 실패되어야 한다.")
+        void duplicate_user() {
+
+            // given
+            CreateUserRequest request1 = createDefaultUser();
+            userService.join(request1);
+
+            CreateUserRequest request2 = CreateUserRequest.builder()
+                    .oauthId("1")
+                    .email("jinwon@gmail.com")
+                    .profileImage("profile.png")
+                    .point(1000)
+                    .nickname("jinwon")
+                    .userRole(String.valueOf(Role.GENERAL))
+                    .build();
+
+            // when
+
+            // then
+            assertThrows(UserDuplicateException.class, () -> userService.join(request2));
+        }
     }
 
-    @Test
-    public void 중복_회원_검사() throws Exception {
+    @Nested
+    @DisplayName("회원 조회 테스트")
+    class FindUser {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateUserRequest request2 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
+        @Test
+        @DisplayName("회원 단건 조회 요청시 한 명의 회원이 조회되어야 한다.")
+        void find_single_user() {
 
-        // when
-        userService.join(request1);
+            // given
+            CreateUserRequest request = createDefaultUser();
+            Long savedId = userService.join(request);
 
-        // then
-        assertThrows(UserDuplicateException.class, () -> userService.join(request2));
+            // when
+            User user = userService.findById(savedId);
+
+            // then
+            assertEquals("jinwon@gmail.com", user.getEmail());
+            assertEquals("jinwon", user.getNickname());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 회원을 조회시 예외가 발생해야 한다.")
+        void find_single_user_fail() {
+
+            // given
+            CreateUserRequest request = createDefaultUser();
+            userService.join(request);
+
+            // when
+
+            // then
+            assertThrows(UserNotFoundException.class, () -> userService.findById(100L));
+        }
+
+        @Test
+        @DisplayName("전체 회원 조회시 전체 회원 목록을 반환해야 한다.")
+        void find_users() {
+
+            // given
+            CreateUserRequest request = createDefaultUser();
+            userService.join(request);
+
+            CreateUserRequest request2 = CreateUserRequest.builder()
+                    .oauthId("2")
+                    .email("donggwon@gmail.com")
+                    .profileImage("profile.png")
+                    .point(1000)
+                    .nickname("donggwon")
+                    .userRole(String.valueOf(Role.GENERAL))
+                    .build();
+            userService.join(request2);
+
+            // when
+            List<User> users = userService.findUsers();
+
+            // then
+            assertEquals(2, users.size());
+            assertEquals("jinwon", users.get(0).getNickname());
+        }
     }
 
-    @Test
-    public void 회원_조회() throws Exception {
+    @Nested
+    @DisplayName("회원 수정 테스트")
+    class UpdateUser {
 
-        // given
-        CreateUserRequest request = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
+        @Test
+        @DisplayName("회원 닉네임 수정 요청시 정상적으로 수정되어야 한다.")
+        void update_user_nickname() {
 
-        // when
-        Long userId = userService.join(request);
-        User savedUser = userService.findById(userId);
+            // given
+            CreateUserRequest request = createDefaultUser();
+            Long userId = userService.join(request);
 
-        // then
-        assertEquals(request.nickname(), savedUser.getNickname());
+            UpdateUserRequest updateRequest = new UpdateUserRequest("jinony");
+
+            // when
+            userService.updateNickname(userId, updateRequest);
+            User updateUser = userService.findById(userId);
+
+            // then
+            assertEquals("jinony", updateUser.getNickname());
+        }
+
+        @Test
+        @DisplayName("자신이 아닌 회원의 닉네임을 수정시 예외가 발생해야 한다.")
+        void update_user_nickname_fail() {
+
+            // given
+            CreateUserRequest request = createDefaultUser();
+            userService.join(request);
+
+            UpdateUserRequest updateRequest = new UpdateUserRequest("jinony");
+
+            // when
+
+            // then
+            assertThrows(UserNotFoundException.class, () -> userService.updateNickname(100L, updateRequest));
+        }
     }
 
-    @Test
-    public void 전체_회원_조회() throws Exception {
+    @Nested
+    @DisplayName("회원 탈퇴 테스트")
+    class DeleteUser {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile1.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateUserRequest request2 = new CreateUserRequest("2", "minseok@gmail.com", "profile2.png", 1000, "minseok", String.valueOf(Role.GENERAL));
+        @Test
+        @DisplayName("회원 탈퇴시 회원이 삭제되어야 한다.")
+        void 한delete_user() {
 
-        // when
-        userService.join(request1);
-        userService.join(request2);
-        List<User> users = userService.findUsers();
+            // given
+            CreateUserRequest request = createDefaultUser();
+            Long userId = userService.join(request);
 
-        // then
-        assertEquals(2, users.size());
+            // when
+            userService.deleteUser(userId);
 
-    }
+            // then
+            assertThrows(UserNotFoundException.class, () -> userService.findById(userId));
+        }
 
-    @Test
-    public void 회원_닉네임_수정() throws Exception {
+        @Test
+        @DisplayName("자신이 아닌 회원을 탈퇴하려 했을시 예외가 발생해야 한다.")
+        void delete_user_fail() {
 
-        // given
-        CreateUserRequest request = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
+            // given
+            CreateUserRequest request = createDefaultUser();
+            userService.join(request);
 
-        // when
-        UpdateUserRequest request1 = new UpdateUserRequest("jinony");
-        Long userId = userService.join(request);
-        userService.updateNickname(userId, request1);
-        User updateUser = userService.findById(userId);
+            // when
 
-        // then
-        assertEquals("jinony", updateUser.getNickname());
-    }
-
-    @Test
-    public void 회원_탈퇴() throws Exception {
-
-        // given
-        CreateUserRequest request = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-
-        // when
-        Long userId = userService.join(request);
-        userService.deleteUser(userId);
-
-        // then
-        assertThrows(UserNotFoundException.class, () -> userService.findById(userId));
+            // then
+            assertThrows(UserNotFoundException.class, () -> userService.deleteUser(100L));
+        }
     }
 }

--- a/src/test/java/io/wisoft/capstonedesign/service/UserShopServiceTest.java
+++ b/src/test/java/io/wisoft/capstonedesign/service/UserShopServiceTest.java
@@ -1,27 +1,35 @@
 package io.wisoft.capstonedesign.service;
 
-import io.wisoft.capstonedesign.domain.information.web.dto.CreateInformationRequest;
-import io.wisoft.capstonedesign.domain.shop.web.dto.CreateShopRequest;
-import io.wisoft.capstonedesign.domain.user.web.dto.CreateUserRequest;
-import io.wisoft.capstonedesign.domain.usershop.web.dto.CreateOrderRequest;
-import io.wisoft.capstonedesign.domain.usershop.web.dto.UpdateOrderRequest;
-import io.wisoft.capstonedesign.global.enumerated.Role;
 import io.wisoft.capstonedesign.domain.information.application.InformationService;
+import io.wisoft.capstonedesign.domain.information.web.dto.CreateInformationRequest;
 import io.wisoft.capstonedesign.domain.shop.application.ShopService;
+import io.wisoft.capstonedesign.domain.shop.web.dto.CreateShopRequest;
 import io.wisoft.capstonedesign.domain.user.application.UserService;
+import io.wisoft.capstonedesign.domain.user.web.dto.CreateUserRequest;
 import io.wisoft.capstonedesign.domain.usershop.application.UserShopService;
 import io.wisoft.capstonedesign.domain.usershop.persistence.UserShop;
+import io.wisoft.capstonedesign.domain.usershop.web.dto.CreateOrderRequest;
+import io.wisoft.capstonedesign.domain.usershop.web.dto.UpdateOrderRequest;
 import io.wisoft.capstonedesign.global.exception.service.OrderNotFoundException;
+import io.wisoft.capstonedesign.global.exception.service.UserNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static io.wisoft.capstonedesign.setting.data.DefaultInfoData.createDefaultInfo;
+import static io.wisoft.capstonedesign.setting.data.DefaultShopData.createDefaultShop;
+import static io.wisoft.capstonedesign.setting.data.DefaultShopOrderData.createDefaultOrder;
+import static io.wisoft.capstonedesign.setting.data.DefaultUserData.createDefaultUser;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Transactional
@@ -32,153 +40,310 @@ public class UserShopServiceTest {
     @Autowired ShopService shopService;
     @Autowired InformationService informationService;
 
-    @Test
-    public void 주문내역_생성() throws Exception {
+    @Nested
+    @DisplayName("산타샵 주문내역 생성 테스트")
+    class CreateOrder {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateShopRequest request2 = new CreateShopRequest("라면 한 박스", 1000, "ramen.jpg", "포인트로 뜨끈한 라면 한 박스 가져가세요!", 1L);
-        CreateInformationRequest request3 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateOrderRequest request4 = new CreateOrderRequest("배송 전 문자 부탁드립니다", 1L, 1L, 1L);
+        @Test
+        @DisplayName("산타샵 주문내역 생성시 정상적으로 주문이 되어야 한다.")
+        void create_order() {
 
-        // when
-        userService.join(request1);
-        shopService.save(request2);
-        informationService.save(request3);
-        Long savedId = userShopService.save(request4);
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(request4.text(), userShopService.findById(savedId).getText());
+            CreateShopRequest shopRequest = createDefaultShop(userId);
+            Long shopId = shopService.save(shopRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest);
+
+            CreateOrderRequest orderRequest = createDefaultOrder(infoId, shopId, userId);
+
+            // when
+            Long savedId = userShopService.save(orderRequest);
+
+            // then
+            UserShop order = userShopService.findById(savedId);
+            assertEquals("배송 전 문자 부탁드립니다", order.getText());
+        }
+
+        @Test
+        @DisplayName("회원이 아닌 사용자가 주문할시 예외가 발생해야 한다.")
+        void create_order_fail() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateShopRequest shopRequest = createDefaultShop(userId);
+            Long shopId = shopService.save(shopRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest);
+
+            CreateOrderRequest orderRequest = createDefaultOrder(infoId, shopId, 100L);
+
+            // when
+
+            // then
+            assertThrows(UserNotFoundException.class, () -> userShopService.save(orderRequest));
+        }
+
+        @Test
+        @DisplayName("배송정보 없이 주문할시 예외가 발생해야 한다.")
+        void create_order_fail2() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateShopRequest shopRequest = createDefaultShop(userId);
+            Long shopId = shopService.save(shopRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            informationService.save(infoRequest);
+
+            CreateOrderRequest orderRequest = createDefaultOrder(null, shopId, userId);
+
+            // when
+
+            // then
+            assertThrows(InvalidDataAccessApiUsageException.class, () -> userShopService.save(orderRequest));
+        }
     }
 
-    @Test
-    public void 전체_주문내역_조회() throws Exception {
+    @Nested
+    @DisplayName("산타샵 주문내역 조회 테스트")
+    class FindOrder {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateShopRequest request2 = new CreateShopRequest("라면 한 박스", 1000, "ramen.jpg", "포인트로 뜨끈한 라면 한 박스 가져가세요!", 1L);
-        CreateInformationRequest request3 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateOrderRequest request4 = new CreateOrderRequest("배송 전 문자 부탁드립니다", 1L, 1L, 1L);
-        CreateOrderRequest request5 = new CreateOrderRequest("경비실에 맡겨주세요", 1L, 1L, 1L);
+        @Test
+        @DisplayName("주문내역 단건 조회 요청시 한 주문내역이 조회되어야 한다.")
+        void find_single_order() {
 
-        // when
-        userService.join(request1);
-        shopService.save(request2);
-        informationService.save(request3);
-        userShopService.save(request4);
-        userShopService.save(request5);
-        List<UserShop> shopOrders = userShopService.findShopOrders();
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(2, shopOrders.size());
+            CreateShopRequest shopRequest = createDefaultShop(userId);
+            Long shopId = shopService.save(shopRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest);
+
+            CreateOrderRequest orderRequest = createDefaultOrder(infoId, shopId, userId);
+            Long savedId = userShopService.save(orderRequest);
+
+            // when
+            UserShop savedOrder = userShopService.findById(savedId);
+
+            // then
+            assertEquals("배송 전 문자 부탁드립니다", savedOrder.getText());
+            assertEquals(infoId, savedOrder.getInformation().getId());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 주문내역을 조회시 예외가 발생해야 한다.")
+        void find_single_order_fail() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateShopRequest shopRequest = createDefaultShop(userId);
+            Long shopId = shopService.save(shopRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest);
+
+            CreateOrderRequest orderRequest = createDefaultOrder(infoId, shopId, userId);
+            userShopService.save(orderRequest);
+
+            // when
+
+            // then
+            assertThrows(OrderNotFoundException.class, () -> userShopService.findById(100L));
+        }
+
+        @Test
+        @DisplayName("전체 주문내역 조회시 전체 주문내역 목록을 반환해야 한다.")
+        void find_orders() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateShopRequest shopRequest = createDefaultShop(userId);
+            Long shopId = shopService.save(shopRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest);
+
+            CreateOrderRequest orderRequest1 = createDefaultOrder(infoId, shopId, userId);
+            userShopService.save(orderRequest1);
+
+            CreateOrderRequest orderRequest2 = CreateOrderRequest.builder()
+                    .text("경비실에 맡겨주세요")
+                    .infoId(infoId)
+                    .shopId(shopId)
+                    .userId(userId)
+                    .build();
+            userShopService.save(orderRequest2);
+
+            // when
+            List<UserShop> shopOrders = userShopService.findShopOrders();
+
+            // then
+            assertEquals(2, shopOrders.size());
+            assertEquals("경비실에 맡겨주세요", shopOrders.get(1).getText());
+        }
+
+        @Test
+        @DisplayName("전체 주문내역을 페이징을 사용하여 조회시 페이지 번호와 내림차순으로 정렬된 페이지가 반환되어야 한다.")
+        void find_orders_using_paging() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateShopRequest shopRequest = createDefaultShop(userId);
+            Long shopId = shopService.save(shopRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest);
+
+            CreateOrderRequest orderRequest1 = createDefaultOrder(infoId, shopId, userId);
+            userShopService.save(orderRequest1);
+
+            CreateOrderRequest orderRequest2 = CreateOrderRequest.builder()
+                    .text("경비실에 맡겨주세요")
+                    .infoId(infoId)
+                    .shopId(shopId)
+                    .userId(userId)
+                    .build();
+            userShopService.save(orderRequest2);
+            PageRequest request = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+
+            // when
+            List<UserShop> shops = userShopService.findByCreatedDateDescUsingPaging(request).getContent();
+
+            // then
+            assertEquals("경비실에 맡겨주세요", shops.get(0).getText());
+        }
     }
 
-    @Test
-    public void 전체_주문내역_조회_페이징() throws Exception {
+    @Nested
+    @DisplayName("산타샵 주문내역 수정 테스트")
+    class UpdateOrder {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateShopRequest request2 = new CreateShopRequest("라면 한 박스", 1000, "ramen.jpg", "포인트로 뜨끈한 라면 한 박스 가져가세요!", 1L);
-        CreateInformationRequest request3 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateOrderRequest request4 = new CreateOrderRequest("배송 전 문자 부탁드립니다", 1L, 1L, 1L);
-        CreateOrderRequest request5 = new CreateOrderRequest("경비실에 맡겨주세요", 1L, 1L, 1L);
-        PageRequest request = PageRequest.of(0, 5, Sort.by("createdDate").descending());
+        @Test
+        @DisplayName("주문내역 수정시 주문내역 기타사항이 수정되어야 한다.")
+        void update_order() {
 
-        // when
-        userService.join(request1);
-        shopService.save(request2);
-        informationService.save(request3);
-        userShopService.save(request4);
-        userShopService.save(request5);
-        List<UserShop> shopOrders = userShopService.findByCreatedDateDescUsingPaging(request).getContent();
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(request5.text(), shopOrders.get(0).getText());
+            CreateShopRequest shopRequest = createDefaultShop(userId);
+            Long shopId = shopService.save(shopRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest);
+
+            CreateOrderRequest orderRequest = createDefaultOrder(infoId, shopId, userId);
+            Long savedId = userShopService.save(orderRequest);
+
+            UpdateOrderRequest updateRequest = UpdateOrderRequest.builder()
+                    .text("경비실에 맡겨주세요")
+                    .orderId(savedId)
+                    .build();
+
+            // when
+            userShopService.updateBody(savedId, updateRequest);
+            UserShop updateOrder = userShopService.findById(savedId);
+
+            // then
+            assertEquals("경비실에 맡겨주세요", updateOrder.getText());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 주문내역을 수정시 예외가 발생해야 한다.")
+        void update_order_fail() {
+
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
+
+            CreateShopRequest shopRequest = createDefaultShop(userId);
+            Long shopId = shopService.save(shopRequest);
+
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest);
+
+            CreateOrderRequest orderRequest = createDefaultOrder(infoId, shopId, userId);
+            Long savedId = userShopService.save(orderRequest);
+
+            UpdateOrderRequest updateRequest = UpdateOrderRequest.builder()
+                    .text("경비실에 맡겨주세요")
+                    .orderId(savedId)
+                    .build();
+
+            // when
+
+            // then
+            assertThrows(OrderNotFoundException.class, () -> userShopService.updateBody(100L, updateRequest));
+        }
     }
 
-    @Test
-    public void 주문내역_조회() throws Exception {
+    @Nested
+    @DisplayName("산타샵 주문내역 삭제 테스트")
+    class DeleteOrder {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateShopRequest request2 = new CreateShopRequest("라면 한 박스", 1000, "ramen.jpg", "포인트로 뜨끈한 라면 한 박스 가져가세요!", 1L);
-        CreateInformationRequest request3 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateOrderRequest request4 = new CreateOrderRequest("배송 전 문자 부탁드립니다", 1L, 1L, 1L);
+        @Test
+        @DisplayName("주문내역 삭제시 주문내역이 삭제되어야 한다.")
+        void delete_order() {
 
-        // when
-        userService.join(request1);
-        shopService.save(request2);
-        informationService.save(request3);
-        Long savedId = userShopService.save(request4);
-        UserShop savedOrder = userShopService.findById(savedId);
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // then
-        assertEquals(request4.text(), savedOrder.getText());
-    }
+            CreateShopRequest shopRequest = createDefaultShop(userId);
+            Long shopId = shopService.save(shopRequest);
 
-    @Test
-    public void 개별_주문내역_최근순_조회() throws Exception {
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest);
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateShopRequest request2 = new CreateShopRequest("라면 한 박스", 1000, "ramen.jpg", "포인트로 뜨끈한 라면 한 박스 가져가세요!", 1L);
-        CreateInformationRequest request3 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateOrderRequest request4 = new CreateOrderRequest("배송 전 문자 부탁드립니다", 1L, 1L, 1L);
-        CreateOrderRequest request5 = new CreateOrderRequest("경비실에 맡겨주세요", 1L, 1L, 1L);
+            CreateOrderRequest orderRequest = createDefaultOrder(infoId, shopId, userId);
+            Long savedId = userShopService.save(orderRequest);
 
-        // when
-        Long userId = userService.join(request1);
-        shopService.save(request2);
-        informationService.save(request3);
-        userShopService.save(request4);
-        userShopService.save(request5);
-        List<UserShop> orderDESC = userShopService.findByUser(userId);
+            // when
+            userShopService.deleteOrder(savedId);
 
-        // then
-        assertEquals(request5.text(), orderDESC.get(0).getText());
-    }
+            // then
+            assertThrows(OrderNotFoundException.class, () -> userShopService.findById(savedId));
+        }
 
-    @Test
-    public void 주문내역_기타사항_수정() throws Exception {
+        @Test
+        @DisplayName("존재하지 않는 주문내역을 삭제시 예외가 발생해야 한다.")
+        void delete_order_fail() {
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateShopRequest request2 = new CreateShopRequest("라면 한 박스", 1000, "ramen.jpg", "포인트로 뜨끈한 라면 한 박스 가져가세요!", 1L);
-        CreateInformationRequest request3 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateOrderRequest request4 = new CreateOrderRequest("배송 전 문자 부탁드립니다", 1L, 1L, 1L);
+            // given
+            CreateUserRequest userRequest = createDefaultUser();
+            Long userId = userService.join(userRequest);
 
-        // when
-        userService.join(request1);
-        shopService.save(request2);
-        informationService.save(request3);
-        Long savedId = userShopService.save(request4);
+            CreateShopRequest shopRequest = createDefaultShop(userId);
+            Long shopId = shopService.save(shopRequest);
 
-        UpdateOrderRequest updateRequest = new UpdateOrderRequest("경비실에 맡겨주세요", 1L);
-        userShopService.updateBody(savedId, updateRequest);
-        UserShop updateOrder = userShopService.findById(savedId);
+            CreateInformationRequest infoRequest = createDefaultInfo(userId);
+            Long infoId = informationService.save(infoRequest);
 
-        // then
-        assertEquals("경비실에 맡겨주세요", updateOrder.getText());
-    }
+            CreateOrderRequest orderRequest = createDefaultOrder(infoId, shopId, userId);
+            userShopService.save(orderRequest);
 
-    @Test
-    public void 주문내역_삭제() throws Exception {
+            // when
 
-        // given
-        CreateUserRequest request1 = new CreateUserRequest("1", "jinwon@gmail.com", "profile.png", 1000, "jinwon", String.valueOf(Role.GENERAL));
-        CreateShopRequest request2 = new CreateShopRequest("라면 한 박스", 1000, "ramen.jpg", "포인트로 뜨끈한 라면 한 박스 가져가세요!", 1L);
-        CreateInformationRequest request3 = new CreateInformationRequest("윤진원", "대전광역시 유성구", "010-0000-0000", 1L);
-        CreateOrderRequest request4 = new CreateOrderRequest("배송 전 문자 부탁드립니다", 1L, 1L, 1L);
-
-        // when
-        userService.join(request1);
-        shopService.save(request2);
-        informationService.save(request3);
-        Long savedId = userShopService.save(request4);
-
-        userShopService.deleteOrder(savedId);
-
-        // then
-        assertThrows(OrderNotFoundException.class, () -> userShopService.findById(savedId));
+            // then
+            assertThrows(OrderNotFoundException.class, () -> userShopService.deleteOrder(100L));
+        }
     }
 }

--- a/src/test/java/io/wisoft/capstonedesign/setting/data/DefaultDonateData.java
+++ b/src/test/java/io/wisoft/capstonedesign/setting/data/DefaultDonateData.java
@@ -1,0 +1,18 @@
+package io.wisoft.capstonedesign.setting.data;
+
+import io.wisoft.capstonedesign.domain.donate.web.dto.CreateDonateRequest;
+import io.wisoft.capstonedesign.global.enumerated.Tag;
+
+public class DefaultDonateData {
+
+    public static CreateDonateRequest createDefaultDonate(Long userId) {
+
+        return CreateDonateRequest.builder()
+                .title("패딩 나눔합니다.")
+                .image("image.png")
+                .text("안 입는 패딩 기부해요")
+                .tag(String.valueOf(Tag.TOP))
+                .userId(userId)
+                .build();
+    }
+}

--- a/src/test/java/io/wisoft/capstonedesign/setting/data/DefaultDonateOrderData.java
+++ b/src/test/java/io/wisoft/capstonedesign/setting/data/DefaultDonateOrderData.java
@@ -1,0 +1,17 @@
+package io.wisoft.capstonedesign.setting.data;
+
+import io.wisoft.capstonedesign.domain.donateorder.web.dto.CreateOrderRequest;
+
+public class DefaultDonateOrderData {
+
+    public static CreateOrderRequest createDefaultOrder(Long infoId,
+                                                        Long donateId,
+                                                        Long userId) {
+        return CreateOrderRequest.builder()
+                .text("배송전 문자주세요")
+                .infoId(infoId)
+                .donateId(donateId)
+                .userId(userId)
+                .build();
+    }
+}

--- a/src/test/java/io/wisoft/capstonedesign/setting/data/DefaultFindData.java
+++ b/src/test/java/io/wisoft/capstonedesign/setting/data/DefaultFindData.java
@@ -1,0 +1,18 @@
+package io.wisoft.capstonedesign.setting.data;
+
+import io.wisoft.capstonedesign.domain.find.web.dto.CreateFindRequest;
+import io.wisoft.capstonedesign.global.enumerated.Tag;
+
+public class DefaultFindData {
+
+    public static CreateFindRequest createDefaultFind(Long userId) {
+
+        return CreateFindRequest.builder()
+                .title("패딩 찾아봅니다")
+                .image("image.png")
+                .text("안 입는 패딩 기부받아요")
+                .tag(String.valueOf(Tag.TOP))
+                .userId(userId)
+                .build();
+    }
+}

--- a/src/test/java/io/wisoft/capstonedesign/setting/data/DefaultFindOrderData.java
+++ b/src/test/java/io/wisoft/capstonedesign/setting/data/DefaultFindOrderData.java
@@ -1,0 +1,17 @@
+package io.wisoft.capstonedesign.setting.data;
+
+import io.wisoft.capstonedesign.domain.findorder.web.dto.CreateOrderRequest;
+
+public class DefaultFindOrderData {
+
+    public static CreateOrderRequest createDefaultOrder(Long infoId,
+                                                        Long findId,
+                                                        Long userId) {
+        return CreateOrderRequest.builder()
+                .text("배송전 문자주세요")
+                .infoId(infoId)
+                .findId(findId)
+                .userId(userId)
+                .build();
+    }
+}

--- a/src/test/java/io/wisoft/capstonedesign/setting/data/DefaultInfoData.java
+++ b/src/test/java/io/wisoft/capstonedesign/setting/data/DefaultInfoData.java
@@ -1,0 +1,16 @@
+package io.wisoft.capstonedesign.setting.data;
+
+import io.wisoft.capstonedesign.domain.information.web.dto.CreateInformationRequest;
+
+public class DefaultInfoData {
+
+    public static CreateInformationRequest createDefaultInfo(Long userId) {
+
+        return CreateInformationRequest.builder()
+                .username("윤진원")
+                .address("대전광역시 유성구")
+                .phoneNumber("010-0000-0000")
+                .userId(userId)
+                .build();
+    }
+}

--- a/src/test/java/io/wisoft/capstonedesign/setting/data/DefaultShopData.java
+++ b/src/test/java/io/wisoft/capstonedesign/setting/data/DefaultShopData.java
@@ -1,0 +1,17 @@
+package io.wisoft.capstonedesign.setting.data;
+
+import io.wisoft.capstonedesign.domain.shop.web.dto.CreateShopRequest;
+
+public class DefaultShopData {
+
+    public static CreateShopRequest createDefaultShop(Long userId) {
+
+        return CreateShopRequest.builder()
+                .title("라면 한 박스")
+                .price(1000)
+                .image("ramen.jpg")
+                .body("포인트로 뜨끈한 라면 한 박스 가져가세요!")
+                .userId(userId)
+                .build();
+    }
+}

--- a/src/test/java/io/wisoft/capstonedesign/setting/data/DefaultShopOrderData.java
+++ b/src/test/java/io/wisoft/capstonedesign/setting/data/DefaultShopOrderData.java
@@ -1,0 +1,17 @@
+package io.wisoft.capstonedesign.setting.data;
+
+import io.wisoft.capstonedesign.domain.usershop.web.dto.CreateOrderRequest;
+
+public class DefaultShopOrderData {
+
+    public static CreateOrderRequest createDefaultOrder(Long infoId,
+                                                        Long shopId,
+                                                        Long userId) {
+        return CreateOrderRequest.builder()
+                .text("배송 전 문자 부탁드립니다")
+                .infoId(infoId)
+                .shopId(shopId)
+                .userId(userId)
+                .build();
+    }
+}

--- a/src/test/java/io/wisoft/capstonedesign/setting/data/DefaultUserData.java
+++ b/src/test/java/io/wisoft/capstonedesign/setting/data/DefaultUserData.java
@@ -1,0 +1,18 @@
+package io.wisoft.capstonedesign.setting.data;
+
+import io.wisoft.capstonedesign.domain.user.web.dto.CreateUserRequest;
+import io.wisoft.capstonedesign.global.enumerated.Role;
+
+public class DefaultUserData {
+    public static CreateUserRequest createDefaultUser() {
+
+        return CreateUserRequest.builder()
+                .oauthId("1")
+                .email("jinwon@gmail.com")
+                .profileImage("profile.png")
+                .point(1000)
+                .nickname("jinwon")
+                .userRole(String.valueOf(Role.GENERAL))
+                .build();
+    }
+}


### PR DESCRIPTION
### feat:
- 기존의 서비스 단의 테스트 코드는 가독성이 좋지 않고, 객체 생성을 위한 중복 로직이 많았습니다.
- 따라서, 빌더 패턴을 사용해서 가독성을 높이고, 기본 데이터 클래스를 생성해 중복 로직을 줄였습니다.
- 또한, 기존에는 없었던 `@DisplayName` , `@Nested`를 통해 테스트를 명확하게 구분하였습니다.

</br>

### chore:
- 테스트 커버리지 측정을 위해 Jacoco 의존성을 추가하였습니다.
- 향후에는 테스트 커버리지 제한을 걸고, 테스트를 작성해볼 생각입니다.