### PR TITLE
chore: 기존의 h2 데이터베이스에서 PostgreSQL로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'org.webjars:sockjs-client:1.1.2'
     implementation 'org.webjars:stomp-websocket:2.3.3-1'
     implementation 'com.slack.api:slack-api-client:1.29.0'
+    implementation group: 'org.postgresql', name: 'postgresql', version: '42.5.1'
     // front 관련
     implementation 'org.webjars.bower:bootstrap:5.3.0'
     implementation 'org.webjars.bower:vue:2.6.14'


### PR DESCRIPTION
### chore:
- 기존에 사용하던 h2 스프링 인메모리 데이터베이스에서 PostgreSQL로 변경하였습니다.