### PR TITLE
feat: 필수 파라미터 누락 예외 추가 & 에러 코드 변경

### DIFF
--- a/src/main/java/io/wisoft/capstonedesign/domain/chat/web/ChatRoomController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/chat/web/ChatRoomController.java
@@ -18,7 +18,7 @@ public class ChatRoomController {
 
     @GetMapping("/room")
     public String rooms(Model model) {
-        return "/chat/room";
+        return "chat/room";
     }
 
     @GetMapping("/rooms")
@@ -36,7 +36,7 @@ public class ChatRoomController {
     @GetMapping("/room/enter/{roomId}")
     public String roomDetail(Model model, @PathVariable String roomId) {
         model.addAttribute("roomId", roomId);
-        return "/chat/roomDetail";
+        return "chat/roomDetail";
     }
 
     @GetMapping("/room/{roomId}")

--- a/src/main/java/io/wisoft/capstonedesign/global/exception/ErrorCode.java
+++ b/src/main/java/io/wisoft/capstonedesign/global/exception/ErrorCode.java
@@ -9,20 +9,21 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // COMMON -> 가장 흔히 발생하는 예외
-    NOT_FOUND_ACCOUNT("A001", "회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    NOT_FOUND_POST("P001", "게시물을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    NOT_FOUND_INFO("I001", "배송 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    NOT_FOUND_ORDER("O001", "주문 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    NOT_FOUND_ACCOUNT("404", "회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    NOT_FOUND_POST("404", "게시물을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    NOT_FOUND_INFO("404", "배송 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    NOT_FOUND_ORDER("404", "주문 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INVALID_ARGUMENT("400", "필수로 요구되는 파라미터가 없습니다.", HttpStatus.BAD_REQUEST),
 
     // TOKEN -> 토큰 관련 예외
-    NOT_EXIST_TOKEN("T001", "토큰이 존재하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    NOT_EXIST_TOKEN("401", "토큰이 존재하지 않습니다.", HttpStatus.UNAUTHORIZED),
 
     // DUPLICATE -> 중복 예외
-    DUPLICATE_USER("A002", "이미 존재하는 회원입니다.", HttpStatus.CONFLICT),
+    DUPLICATE_USER("409", "이미 존재하는 회원입니다.", HttpStatus.CONFLICT),
 
     // ILLEGAL -> 이상 접근, 서버 에러
-    UNAUTHORIZED_ACCESS("U001", "권한이 없습니다.", HttpStatus.FORBIDDEN),
-    INTERNAL_SERVER_ERROR("S001", "일시적으로 접속이 원활하지 않습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    UNAUTHORIZED_ACCESS("403", "권한이 없습니다.", HttpStatus.FORBIDDEN),
+    INTERNAL_SERVER_ERROR("500", "일시적으로 접속이 원활하지 않습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
 
     private final String code;

--- a/src/main/java/io/wisoft/capstonedesign/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/wisoft/capstonedesign/global/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -25,6 +26,16 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * 필수로 요구되는 파라미터 누락시 발생하는 예외
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(final HttpServletRequest request) {
+
+        createLogAndSendAsync(new InvalidArgumentException(), request);
+        return getErrorResponse(new InvalidArgumentException().getErrorCode());
+    }
+
+    /**
      * 회원 엔티티 부재시 발생하는 예외
      */
     @ExceptionHandler(UserNotFoundException.class)
@@ -38,7 +49,7 @@ public class GlobalExceptionHandler {
      * 게시물(산타샵 물품) 엔티티 부재시 발생하는 예외
      */
     @ExceptionHandler(PostNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handlePostNotFoundException(final PostNotFoundException exception,final HttpServletRequest request) {
+    public ResponseEntity<ErrorResponse> handlePostNotFoundException(final PostNotFoundException exception, final HttpServletRequest request) {
 
         createLogAndSendAsync(exception, request);
         return getErrorResponse(exception.getErrorCode());
@@ -97,7 +108,7 @@ public class GlobalExceptionHandler {
     /**
      * 콘솔 에러 로그 생성 및 스레드풀을 사용하여 예외 메시지를 비동기로 Slack에 전달
      */
-    private void createLogAndSendAsync(final RuntimeException exception, final HttpServletRequest request) {
+    private void createLogAndSendAsync(final Exception exception, final HttpServletRequest request) {
 
         log.error("Exception:{}, {}, {} \n",
                 exception.toString(),

--- a/src/main/java/io/wisoft/capstonedesign/global/exception/service/InvalidArgumentException.java
+++ b/src/main/java/io/wisoft/capstonedesign/global/exception/service/InvalidArgumentException.java
@@ -1,0 +1,16 @@
+package io.wisoft.capstonedesign.global.exception.service;
+
+import io.wisoft.capstonedesign.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class InvalidArgumentException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final String message;
+
+    public InvalidArgumentException() {
+        this.errorCode = ErrorCode.INVALID_ARGUMENT;
+        this.message = ErrorCode.INVALID_ARGUMENT.getMessage();
+    }
+}


### PR DESCRIPTION
### feat:
- 기존에는 dto를 통해 필수적으로 받는 파라미터가 누락되었을때 기본적인 `MethodArgumentNotValidException` 으로 설정이 되어있었습니다.
- 따라서, 해당 예외를 공통적으로 핸들링하는 필터를 추가하고, 커스텀 예외를 반환하고 Slack에도 알림이 가게 설정하였습니다.

</br>

### refactor:
- 기존에는 클라이언트에게 반환하는 에러 코드가 `A001` 같은 형태로 알아보기 어려웠습니다.
- 따라서, HttpStatus가 있음에도 불구하고 `400`, `404` 와 같은 직관적인 형태로 변경하였습니다.

</br>

### fix:
- 배포시 API에서 `/chat/room` 과 같은 형태로 요청을 보내면 템플릿을 찾을 수 없는 오류가 발생했습니다.
- 따라서, `/` 를 제외한 `chat/room` 으로 변경하여 해결하였습니다.