### PR TITLE
fix: 배포시 불필요한 파일 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,3 +73,7 @@ jacocoTestReport {
         }))
     }
 }
+
+jar {
+    enabled = false
+}


### PR DESCRIPTION
### fix:
- 배포시 `plain jar` 파일이 생성되어 파일명이 중복되어 생기는 오류를 방지하기 위해 설정을 추가하였습니다.